### PR TITLE
docs(readme): clarify GitHub Copilot install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,22 @@ If you just want to use the skills, start with **Quick start**.
 
 ## 🚀 Quick start
 
+For Fusion issue-authoring with GitHub Copilot, use the explicit agent-targeted install command:
+
+```bash
+npx skills add equinor/fusion-skills \
+	--skill fusion-issue-authoring \
+	--skill fusion-issue-author-feature \
+	--skill fusion-issue-author-user-story \
+	--skill fusion-issue-author-task \
+	--skill fusion-issue-author-bug \
+	--agent github-copilot \
+	-y
+```
+
+For GitHub Copilot project installs, skills are placed in `.agents/skills`.
+See https://skills.sh for CLI behavior and agent support details.
+
 List what’s available:
 
 ```bash
@@ -98,7 +114,7 @@ If you are developing or maintaining skills in this repository, use `CONTRIBUTIN
 <details>
 	<summary>Where do skills get installed?</summary>
 
-- Project installs typically land in `.github/skills/` in the current repo.
+- For GitHub Copilot project installs, skills land in `.agents/skills/` in the current repo.
 - Personal installs use your Copilot user-level skills location.
 
 </details>


### PR DESCRIPTION
## Why

`README.md` did not clearly document the recommended GitHub Copilot install command for Fusion issue-authoring skills, which caused ambiguous installs and confusion about install location conventions.

## Current behavior

- Install guidance can be interpreted too broadly for agent targeting.
- Project install location notes can conflict with GitHub Copilot conventions.

## New behavior

- Quick start now includes an explicit GitHub Copilot-focused command with:
	- `--agent github-copilot`
	- explicit Fusion issue-authoring skill selections
	- `-y` for non-interactive install
- The long command example is formatted as a readable multiline bash snippet.
- Install location guidance now explicitly states GitHub Copilot project installs use `.agents/skills/`.
- Added a reference to `https://skills.sh` for CLI and agent behavior details.

## References

- Issue(s): Closes https://github.com/equinor/fusion-core-tasks/issues/400
- Related PR(s): none
- Docs / specs: https://skills.sh

## Reviewer focus

- Start here (files/areas): `README.md` Quick start + install-location details section
- Verify these behavior changes: command clarity for GitHub Copilot and `.agents/skills/` guidance
- Risky or security-sensitive parts: none

## Self review checklist

- [x] I scoped this PR to one clear purpose.
- [x] I followed [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I did not include secrets, credentials, or sensitive data.
- [x] I reviewed my own diff for clarity and unintended changes.