### PR TITLE
docs: clarify issue-closing keyword guidance

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -22,5 +22,6 @@ Notes:
 - You can include multiple skills in one changeset file.
 - PR validation enforces that changed skills are present in updated `.changeset/*.md` files.
 - Use non-closing issue references by default in changeset bodies (for example `Refs: owner/repo#123`).
-- Use auto-closing keywords intentionally (for example `Fixes:`/`Resolves:`) when the skill fix in the release PR should close that issue on merge.
+- Use auto-closing keywords intentionally when the skill fix in the release PR should close that issue on merge.
+- Use GitHub issue-closing keywords with direct references (for example `fixes owner/repo#123`, `resolves owner/repo#123`, or `closes owner/repo#123`).
 - Keep in mind that release PR/changelog generation can propagate these strings and trigger merge-time issue closure.

--- a/.changeset/issue-402-closing-keywords-guidance.md
+++ b/.changeset/issue-402-closing-keywords-guidance.md
@@ -1,0 +1,9 @@
+---
+"fusion-issue-authoring": patch
+---
+
+Clarify issue-closing keyword guidance across skill and contributor docs:
+
+- align wording to keyword families (`fix|fixes|resolve|resolves|close|closes`)
+- standardize direct issue reference examples (`owner/repo#123`)
+- keep `Refs`/`Ref` as the default for non-closing references

--- a/.changeset/issue-402-issue-automation-reliability.md
+++ b/.changeset/issue-402-issue-automation-reliability.md
@@ -9,4 +9,4 @@ Improve issue automation reliability in `fusion-issue-authoring`:
 - guard `set -u` in VS Code integrated zsh sessions to avoid shell integration hook failures
 - update runbook/docs snippets to use the robust pattern and verification command
 
-Resolves: equinor/fusion-core-tasks#402
+resolves: equinor/fusion-core-tasks#402

--- a/.github/instructions/pr-workflow.instructions.md
+++ b/.github/instructions/pr-workflow.instructions.md
@@ -35,4 +35,5 @@ Apply this guidance when creating, updating, or finalizing pull requests.
 - Check code and docs against repository guides (`CONTRIBUTING.md`, `contribute/`, and relevant `.github/instructions/*.instructions.md`).
 - Confirm validation commands run.
 - For changeset-driven skill PRs, default to non-closing issue references in changeset and PR text (`Ref`/`Refs`).
-- Use issue-closing keywords (`Fixes`/`Resolves`) only when the release PR merge is intended to close the issue because the skill fix directly resolves it.
+- Use issue-closing keywords (`fix|fixes|resolve|resolves|close|closes`) only when the release PR merge is intended to close the issue because the skill fix directly resolves it.
+- Use direct references like `fixes owner/repo#123`.

--- a/contribute/04-versioning-and-release.md
+++ b/contribute/04-versioning-and-release.md
@@ -19,7 +19,8 @@ SemVer meaning in this repo:
 
 1. Add a `.changeset/*.md` file describing skill-level bump(s) and impact in skill-changing PRs
 	- In changeset body text, use non-closing references by default (`Refs: owner/repo#123`).
-	- Use auto-closing keywords (`Fixes:`/`Resolves:`) only when the release PR should close the issue because the skill fix directly resolves it.
+	- Use auto-closing keywords only when the release PR should close the issue because the skill fix directly resolves it.
+	- Use GitHub issue-closing keywords with direct references (for example `fixes owner/repo#123`, `resolves owner/repo#123`, or `closes owner/repo#123`).
 	- Remember that changeset text can be propagated into release PR/changelog content and may close issues when the release PR merges.
 2. Let release automation apply affected skill `metadata.version` bumps
 3. Tag the repository release

--- a/skills/fusion-issue-authoring/SKILL.md
+++ b/skills/fusion-issue-authoring/SKILL.md
@@ -193,3 +193,4 @@ Always:
 - Keep drafts concise and editable
 - Prefer WHAT/WHY over implementation HOW in issue text
 - Use full repository issue references (for example `owner/repo#123`)
+- Use issue-closing keywords when closure is intended (for example `fixes owner/repo#123`, `resolves owner/repo#123`, or `closes owner/repo#123`)


### PR DESCRIPTION
## Why

Clarify and align guidance for issue-closing references in changesets/PR text to avoid confusion around keyword usage and parsing.

## Current behavior

Documentation and instructions used mixed phrasing (`Fixes:`/`Resolves:` and capitalization-oriented wording), which made expected issue-closing syntax unclear.

## New behavior

Guidance now consistently:
- keeps non-closing references as default (`Ref`/`Refs`),
- allows explicit closing keywords as a verb family (`fix|fixes|resolve|resolves|close|closes`), and
- emphasizes direct repository references like `fixes owner/repo#123`.

Also updates the related skill guidance and current changeset wording for issue #402 context.

## References

- Issue(s):
- Related PR(s):
- Docs / specs: contribute/04-versioning-and-release.md, .changeset/README.md

## Reviewer focus

- Start here (files/areas):
  - `.github/instructions/pr-workflow.instructions.md`
  - `contribute/04-versioning-and-release.md`
  - `.changeset/README.md`
  - `skills/fusion-issue-authoring/SKILL.md`
- Verify these behavior changes:
  - wording is consistent across docs and skill instructions,
  - examples use direct `owner/repo#123` references,
  - no implicit requirement on capitalization.
- Risky or security-sensitive parts:
  - none (documentation-only changes).

## Self review checklist

- [x] I scoped this PR to one clear purpose.
- [x] I followed [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I did not include secrets, credentials, or sensitive data.
- [x] I reviewed my own diff for clarity and unintended changes.
