### PR TITLE
User Story: ShellCheck validation for skill scripts

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -45,6 +45,19 @@ jobs:
       - name: Validate skills and counts
         run: bun run validate:skills
 
+      - name: Detect changed skill scripts
+        id: changed_skill_scripts
+        uses: tj-actions/changed-files@v47
+        with:
+          files: |
+            skills/**/scripts/**
+
+      - name: ShellCheck changed skill scripts
+        if: steps.changed_skill_scripts.outputs.any_changed == 'true'
+        uses: docker://koalaman/shellcheck:stable
+        with:
+          args: ${{ steps.changed_skill_scripts.outputs.all_changed_files }}
+
       - name: Validate skill version bumps and changesets (PR only)
         if: github.event_name == 'pull_request'
         run: bun run validate:pr


### PR DESCRIPTION
## Why

Add CI enforcement for shell scripts shipped in skills so script issues are caught before release.

## Current behavior

`Validate Skills` does not run ShellCheck for `skills/**/scripts/**`, so shell issues can pass CI unnoticed.

## New behavior

`Validate Skills` now:
- detects changes under `skills/**/scripts/**`;
- runs ShellCheck using `docker://koalaman/shellcheck:stable` only when such files changed;
- fails the workflow when ShellCheck reports findings.

When no skill script files changed, the ShellCheck step is skipped.

## References

- Issue(s): resolves equinor/fusion-core-tasks#435
- Related PR(s):
- Docs / specs:

## Reviewer focus

- Start here (files/areas): `.github/workflows/validate-skills.yml`
- Verify these behavior changes:
  - ShellCheck runs only when `skills/**/scripts/**` changed.
  - ShellCheck receives changed file paths from `tj-actions/changed-files`.
  - Workflow fails if ShellCheck reports issues.
- Risky or security-sensitive parts:
  - Shell scripts are executed in varied environments; lint gating reduces risk.

## Self review checklist

- [x] I scoped this PR to one clear purpose.
- [x] I followed [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I did not include secrets, credentials, or sensitive data.
- [x] I reviewed my own diff for clarity and unintended changes.
