### PR TITLE
fix: remove npm cache from skills-update workflow to support repos without lock files

### DIFF
--- a/.github/workflows/skills-update.yml
+++ b/.github/workflows/skills-update.yml
@@ -94,13 +94,11 @@ jobs:
       # -----------------------------------------------------------------------
       # STEP 2: Setup runtime environment
       # -----------------------------------------------------------------------
-      # Install Node.js 24 and cache npm dependencies to speed up subsequent
-      # skill installation.
-      - name: Setup Node.js + npm cache
+      # Install Node.js 24 for running skill commands.
+      - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 24
-          cache: 'npm'
 
       # -----------------------------------------------------------------------
       # STEP 3: Download and refresh agent skills


### PR DESCRIPTION
## Problem
The `skills-update` workflow fails when called by repositories that don't have npm lock files (e.g., `fusion-core-tasks`). The error occurs because the workflow has `cache: 'npm'` enabled in the `setup-node@v6` step, which requires a lock file to be present.

## Solution
Removed the npm cache configuration entirely. This allows the workflow to run successfully in repositories with or without npm lock files.

## Changes
- Remove `cache: 'npm'` from the Node.js setup step
- Simplify the step to only install Node.js 24

This is a minimal change that maintains compatibility while fixing the workflow failure.