### PR TITLE
fix: correct cron schedule and permissions placement in skills-update example

### DIFF
--- a/.github/workflows/skills-update.yml
+++ b/.github/workflows/skills-update.yml
@@ -17,6 +17,10 @@
 #       - cron: '0 2 * * 1'
 #     workflow_dispatch:  # Also allow manual trigger
 #   
+#   permissions:
+#     contents: write      # Commit skill changes to repository
+#     pull-requests: write # Create and manage pull requests
+#   
 #   concurrency:
 #     # Ensure only one skills-upgrade runs per branch at a time
 #     group: skills-upgrade-${{ github.ref }}
@@ -25,9 +29,6 @@
 #   jobs:
 #     upgrade:
 #       uses: equinor/fusion-skills/.github/workflows/skills-update.yml@main
-#       permissions:
-#         contents: write      # Commit skill changes to repository
-#         pull-requests: write # Create and manage pull requests
 #
 #   Notes:
 #   - Replace @main with a specific version tag to pin to a release

--- a/README.md
+++ b/README.md
@@ -82,9 +82,13 @@ name: Upgrade Agent Skills
 
 on:
   schedule:
-    # Run every Monday at 2 AM UTC
-    - cron: '0 2 * * 1'
+    # Run weekdays at 8 AM UTC
+    - cron: '0 8 * * 1-5'
   workflow_dispatch:  # Allow manual trigger
+
+permissions:
+  contents: write
+  pull-requests: write
 
 concurrency:
   group: skills-upgrade-${{ github.ref }}
@@ -93,9 +97,6 @@ concurrency:
 jobs:
   upgrade:
     uses: equinor/fusion-skills/.github/workflows/skills-update.yml@main
-    permissions:
-      contents: write
-      pull-requests: write
 ```
 
 ### Configuration notes


### PR DESCRIPTION
## Summary
Fixes incorrect documentation examples in the `skills-update.yml` workflow template.

## Changes
- **Cron schedule**: Updated example from `'0 2 * * 1'` to `'0 8 * * 1-5'` to match the actual workflow implementation (weekdays at 8 AM UTC)
- **Permissions placement**: Moved `permissions` block from job context to root level (correct YAML structure for reusable workflows)
- **Files updated**: 
  - [README.md](README.md)
  - [.github/workflows/skills-update.yml](.github/workflows/skills-update.yml)

## Related issues
- resolves equinor/fusion-core-tasks#473
- documents equinor/fusion-skills#52