### PR TITLE
Add fusion-discover-skills experimental skill for MCP-backed discovery

### DIFF
--- a/.changeset/add-fusion-find-skills.md
+++ b/.changeset/add-fusion-find-skills.md
@@ -1,0 +1,14 @@
+---
+"fusion-discover-skills": minor
+---
+
+Add an experimental MCP-backed skills discovery skill that routes user requests through the Fusion skills index and returns actionable next-step guidance.
+
+- Detect query, install, update, and remove intent before calling the skills MCP tool
+- Preserve advisory lifecycle commands exactly when MCP returns them
+- Allow GitHub MCP, shell listing, and GraphQL-backed discovery fallback when Fusion MCP is unavailable
+- Add a follow-up question bank for vague requests so discovery can narrow to the right skill before searching
+- Place the first iteration in the experimental skill lane
+- Require explicit low-confidence handling instead of guessed matches
+
+resolves equinor/fusion-core-tasks#412

--- a/skills/.experimental/fusion-discover-skills/SKILL.md
+++ b/skills/.experimental/fusion-discover-skills/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: fusion-discover-skills
+description: 'Discovers relevant Fusion skills through Fusion MCP first, falls back to GitHub-backed catalog inspection when needed, returns concise matches with purpose and next-step guidance, and handles install, update, or remove intent without guesswork. USE FOR: finding a skill for a task, asking what to install, checking update or remove guidance, discovering available Fusion skills. DO NOT USE FOR: creating new skills, performing the task itself, or inventing results when discovery signals are unavailable.'
+license: MIT
+compatibility: Works best with Fusion MCP access via `mcp_fusion_skills`. When Fusion MCP is unavailable, this skill can fall back to GitHub MCP or read-only `gh` and GraphQL catalog inspection.
+metadata:
+   version: "0.0.0"
+   status: experimental
+   owner: "@equinor/fusion-core"
+   tags:
+      - fusion
+      - skills
+      - discovery
+      - mcp
+      - github
+      - install
+   mcp:
+      suggested:
+         - mcp_fusion
+         - github
+---
+
+# Discover Fusion Skills
+
+## When to use
+
+Use this skill when a user needs to discover which Fusion skill fits a task or wants MCP-backed guidance for installing, updating, or removing a skill.
+
+Typical triggers:
+- "find a skill for this"
+- "what Fusion skill should I use?"
+- "is there a skill for GitHub issue authoring?"
+- "how do I install the right Fusion skill?"
+- "how do I update or remove installed Fusion skills?"
+- "what skills are available for this workflow?"
+
+## When not to use
+
+Do not use this skill for:
+- creating or editing skills in a repository
+- doing the underlying task directly instead of helping with discovery
+- guessing skill matches when discovery data is unavailable
+- automatically installing, updating, or removing skills without the user's request
+
+## Required inputs
+
+Collect before responding:
+- the user's goal or query in their own words
+- the intended action: `query`, `install`, `update`, or `remove`
+- the kind of skill the user is looking for: domain, workflow, or desired outcome
+- the active agent/client name when install guidance is needed and not already obvious
+- any constraints that materially change the recommendation, such as target runtime or repository context
+
+If key inputs are missing, ask only the smallest question needed to resolve the intent.
+Use `references/follow-up-questions.md` for clarifying vague requests about which skill or workflow the user wants.
+
+## Instructions
+
+If subagents are available, use the bundled advisor agents for specific discovery scenarios:
+- `agents/fusion-mcp-advisor.md` when Fusion MCP is available — this is the primary discovery path
+- `agents/github-mcp-advisor.md` when Fusion MCP is unavailable but GitHub MCP search is available
+- `agents/github-raw-search-advisor.md` as a final fallback using read-only CLI and GraphQL inspection
+
+If the runtime does not support bundled agents, follow the same workflow inline as described below.
+
+Main workflow:
+
+1. Detect the user's intent.
+   - Treat broad "what skill fits this?" requests as `query`.
+   - Treat "install/add", "update/check updates", and "remove/uninstall" requests as explicit lifecycle intent.
+   - If the request mixes discovery and lifecycle steps, prioritize discovery first, then include the lifecycle guidance that follows from the selected skill.
+2. Ask follow-up questions when the target skill is still unclear.
+   - If the request is vague, ask a minimal clarifying question about the task, domain, or workflow they want help with.
+   - Prefer questions that narrow the search space quickly: what they are trying to do, whether they want to discover, install, update, or remove a skill, and whether they already know a likely area such as GitHub workflow, MCP setup, or skill authoring.
+   - Use `references/follow-up-questions.md` as the default question bank.
+3. Ask for missing agent context only when needed.
+   - If the user wants install guidance and the active agent is not clear, ask which agent/client the command should target.
+   - Do not ask for agent details for plain discovery requests.
+4. Query Fusion MCP first when available.
+   - Call `mcp_fusion_skills` with the user's wording.
+   - Use auto intent detection by default, but set `intent` explicitly when the user clearly wants `install`, `update`, `remove`, or `query`.
+   - Pass `agent` for install intent when known so the advisory command is directly usable.
+   - Start with a small ranked set, usually top 3 to top 5 results.
+5. Fall back to GitHub-backed discovery when Fusion MCP is unavailable or too weak.
+   - Prefer GitHub MCP repository or search tools when they are available in the current client.
+   - Otherwise use read-only shell-based inspection against trusted sources only, such as `npx skills add --list <source>`, local `skills/**/SKILL.md` searches, `gh search code`, or `gh api graphql` against the catalog repository.
+   - Use GraphQL only when structured repository data is needed and the higher-level MCP or search tools do not expose it cleanly.
+   - Treat GitHub-derived lifecycle guidance as fallback guidance unless Fusion MCP returned an explicit advisory command.
+   - Never use remote-script execution patterns or shell pipelines that execute fetched content.
+6. Do one refinement pass when the first result set is weak.
+   - Rephrase the query with clearer domain keywords from the user's request.
+   - Stop after one refinement pass; do not keep searching indefinitely.
+7. Return actionable results.
+   - For each recommended skill, include:
+     - skill name
+     - one-sentence purpose
+     - why it matches the user's task
+     - the next best action
+   - When MCP returns lifecycle guidance, relay the advisory command or instruction exactly, including any placeholder that still needs user input.
+   - When fallback discovery is used instead, label the source clearly as GitHub MCP, shell listing, code search, or GraphQL-derived guidance.
+   - When a skill is selected, include enough usage guidance that the user can proceed without another discovery round.
+8. Handle low-confidence or no-match outcomes explicitly.
+   - Say that no strong match was found or that the recommendation is uncertain.
+   - If there are near matches, present them as tentative.
+   - Suggest the next best action: broaden the query, continue without a skill, or capture the gap for future skill authoring.
+9. Keep the response scoped to discovery.
+   - Do not install, update, or remove anything unless the user explicitly asks you to execute that step.
+   - If Fusion MCP is unavailable, say so clearly and identify which GitHub-backed fallback path was used instead of inventing catalog results.
+
+## Examples
+
+- User: "Find a Fusion skill for GitHub issue authoring."
+  - Result: return `fusion-issue-authoring`, explain that it routes to issue-type-specific skills, and include the install guidance or next step returned by MCP.
+- User: "How do I update my installed Fusion skills?"
+  - Result: call `mcp_fusion_skills` with `intent: update` and return the advisory update command or instructions from MCP.
+- User: "Is there a skill for this obscure workflow?"
+   - Result: if Fusion MCP is unavailable or yields weak matches, use GitHub-backed fallback discovery, say whether the match is tentative, and suggest the next best action.
+
+## Expected output
+
+Return:
+- detected intent (`query`, `install`, `update`, or `remove`)
+- source used for the recommendation (`mcp_fusion_skills`, GitHub MCP, shell listing, code search, or GraphQL fallback)
+- ranked skill suggestions when available
+- concise description of each recommended skill
+- next-step guidance for the chosen result
+- advisory install/update/remove command when MCP provides one
+- clear uncertainty language and a fallback next action when no strong match exists
+
+## Agents
+
+Helper agents for specific discovery scenarios (when subagents are available):
+
+- [agents/fusion-mcp-advisor.md](agents/fusion-mcp-advisor.md) — use when Fusion MCP is available
+- [agents/github-mcp-advisor.md](agents/github-mcp-advisor.md) — use when Fusion MCP is unavailable but GitHub MCP is available
+- [agents/github-raw-search-advisor.md](agents/github-raw-search-advisor.md) — use as final fallback with read-only CLI/GraphQL
+
+## References
+
+- [references/follow-up-questions.md](references/follow-up-questions.md) — clarifying questions for vague requests
+
+## Safety & constraints
+
+Never:
+- invent skill names, availability, or install/update/remove commands
+- present low-confidence matches as certain
+- use remote-script execution patterns or unsafe shell pipelines during fallback discovery
+- mutate the user's environment unless they explicitly ask you to execute the next step
+
+Always:
+- prefer Fusion MCP first, then GitHub MCP, then read-only shell or GraphQL fallback
+- keep suggestions concise and task-focused
+- preserve any advisory command text exactly when MCP returns it
+- label GitHub-derived fallback guidance clearly when MCP was not the source
+- state uncertainty plainly when the evidence is weak

--- a/skills/.experimental/fusion-discover-skills/agents/fusion-mcp-advisor.md
+++ b/skills/.experimental/fusion-discover-skills/agents/fusion-mcp-advisor.md
@@ -1,0 +1,56 @@
+# Fusion MCP Advisor
+
+Use this agent when `mcp_fusion_skills` is available. This is the preferred discovery route because it already understands Fusion skill inventory, intent-aware lifecycle guidance, and advisory install commands.
+
+## When to use
+
+- The user asks which Fusion skill fits a task
+- The user wants install, update, or remove guidance for a Fusion skill
+- Fusion MCP is available and responding normally
+
+## Inputs to collect
+
+- The user's task or goal in their own words
+- Intent: `query`, `install`, `update`, or `remove`
+- Agent name when install guidance should be executable instead of templated
+
+## Workflow
+
+1. Detect lifecycle intent from the request.
+2. Call `mcp_fusion_skills` with the user's wording.
+3. Set `intent` explicitly when the user clearly asked to install, update, remove, or only query.
+4. Pass `agent` for install intent when the active client is known.
+5. Start with a short ranked result set, usually top 3 to top 5.
+6. If the results are weak, do one refinement pass with sharper domain words from the request.
+7. Return the best matches with purpose, fit, and next step.
+
+## Response contract
+
+For each recommended skill, include:
+
+- Skill name
+- One-sentence purpose
+- Why it matches the user's task
+- The next best action
+
+When MCP returns advisory lifecycle guidance:
+
+- Preserve the command or instruction text exactly
+- Keep placeholders intact when MCP requires the user to provide a value
+- Label the response as Fusion MCP-derived guidance
+
+## Low-confidence handling
+
+- State clearly when no strong match exists
+- Present near matches as tentative, not certain
+- Suggest broadening the query or proceeding without a skill when appropriate
+
+## Example
+
+User request: "Find a Fusion skill for GitHub issue authoring."
+
+Expected outcome:
+
+- Recommend `fusion-issue-authoring`
+- Explain that it routes to issue-type-specific companion skills
+- Include the next installation or usage step returned by Fusion MCP

--- a/skills/.experimental/fusion-discover-skills/agents/github-mcp-advisor.md
+++ b/skills/.experimental/fusion-discover-skills/agents/github-mcp-advisor.md
@@ -1,0 +1,51 @@
+# GitHub MCP Advisor
+
+Use this agent when Fusion MCP is unavailable or too weak, but GitHub MCP search or repository inspection tools are available.
+
+## When to use
+
+- Fusion MCP is unavailable, failing, or returning weak matches
+- The client can search GitHub repositories through MCP
+- You need repository-backed evidence before recommending a skill
+
+## Search targets
+
+Prefer trusted catalog sources first:
+
+- The target Fusion skill catalog repository
+- Repository `skills/**/SKILL.md` files
+- Skill frontmatter fields such as `name`, `description`, `metadata.tags`, and `metadata.mcp`
+- Repository-level install docs when they clarify next-step usage
+
+## Workflow
+
+1. Search the repository for likely skill matches using GitHub MCP search or file-content tools.
+2. Prefer exact skill package documents over README summaries when both are available.
+3. Read enough of the matching `SKILL.md` files to verify:
+   - what the skill does
+   - when to use it
+   - when not to use it
+   - any MCP or lifecycle constraints
+4. If several skills are plausible, rank them by closeness to the user's task.
+5. Derive the next best action from the skill's own guidance or the repository's install pattern.
+6. Label the output as GitHub MCP-derived fallback guidance.
+
+## Response contract
+
+Return:
+
+- The skill name
+- A concise purpose summary grounded in the skill content
+- Why it matches the request
+- The next best action
+- A clear note that GitHub MCP was used as fallback because Fusion MCP was unavailable or weak
+
+## Safety constraints
+
+- Do not invent missing skill metadata
+- Do not treat repository-level hints as stronger than the skill's own `SKILL.md`
+- Do not mutate repository or GitHub state during discovery
+
+## Example
+
+If Fusion MCP cannot answer "what skill should I use for issue authoring", use GitHub MCP to inspect `skills/fusion-issue-authoring/SKILL.md`, confirm it is an orchestrator for issue drafting, and return that recommendation with the repository's install pattern as the next step.

--- a/skills/.experimental/fusion-discover-skills/agents/github-raw-search-advisor.md
+++ b/skills/.experimental/fusion-discover-skills/agents/github-raw-search-advisor.md
@@ -1,0 +1,56 @@
+# GitHub Raw Search Advisor
+
+Use this agent only when Fusion MCP and GitHub MCP are not available or are insufficient. This is a read-only fallback based on trusted repository inspection through local search, `gh` CLI, and GraphQL.
+
+## When to use
+
+- Fusion MCP is unavailable or too weak
+- GitHub MCP search is unavailable
+- A trusted catalog repository or local checkout is accessible
+
+## Preferred read-only sources
+
+- Local `skills/**/SKILL.md` files in a checked-out repository
+- `npx skills add --list <source>` for inventory-style discovery
+- `gh search code` against the catalog repository
+- `gh api graphql` when structured repository data is needed
+
+## Workflow
+
+1. Start with the least expensive trusted signal:
+   - local file search if the repository is checked out
+   - otherwise `npx skills add --list <source>` for a catalog listing
+2. If the listing is too broad, narrow with code search terms that reflect the user's task.
+3. Read the matching `SKILL.md` files and confirm scope from the skill itself.
+4. Use GraphQL only when you need structured repository data that search output does not expose clearly.
+5. Return the recommendation with an explicit note that it came from raw GitHub or local catalog inspection.
+
+## Safe command patterns
+
+Examples of acceptable read-only commands:
+
+```bash
+npx skills add --list equinor/fusion-skills
+gh search code 'issue authoring repo:equinor/fusion-skills path:skills language:Markdown'
+gh api graphql -f query='query($owner:String!, $repo:String!, $expr:String!) { repository(owner:$owner, name:$repo) { object(expression:$expr) { ... on Blob { text } } } }' -F owner=equinor -F repo=fusion-skills -F expr='main:skills/fusion-issue-authoring/SKILL.md'
+```
+
+## Safety constraints
+
+- Never execute fetched shell content
+- Never use remote-script execution patterns such as `curl ... | sh`
+- Keep shell usage read-only during discovery
+- Treat GraphQL data as repository evidence, not as permission to mutate anything
+
+## Response contract
+
+Return:
+
+- The source used: local search, skills CLI list, GitHub code search, or GraphQL
+- The best matching skill or a clear no-match statement
+- Why the match is strong or tentative
+- The next best action the user can take
+
+## Example
+
+If only `gh` CLI is available, search the catalog repo for a workflow keyword, open the matching `SKILL.md`, verify the use case, and return the result as a fallback recommendation with clear uncertainty if the match is only approximate.

--- a/skills/.experimental/fusion-discover-skills/references/follow-up-questions.md
+++ b/skills/.experimental/fusion-discover-skills/references/follow-up-questions.md
@@ -1,0 +1,41 @@
+# Follow-up Questions
+
+Use these when the user's request is too vague to tell which Fusion skill they actually want.
+
+Ask the smallest set of questions needed to narrow the search.
+
+## 1. Clarify the goal
+
+- What are you trying to do right now?
+- Which workflow or outcome do you want help with?
+- Are you looking for a skill to discover information, automate a workflow, write GitHub artifacts, or set up tooling?
+
+## 2. Clarify the action
+
+- Do you want to find a skill, install one, update installed skills, or remove one?
+- Do you already know the rough area, such as issue authoring, MCP setup, skill authoring, or review resolution?
+
+## 3. Clarify the domain
+
+- Is this mainly about GitHub workflows, Fusion MCP, skill authoring, or another Fusion-specific workflow?
+- Is the task repository-specific, or are you looking for a generally useful Fusion skill?
+
+## 4. Clarify install context
+
+- If you want installation guidance, which agent or client should the command target?
+- Do you want a next-step recommendation only, or an install/update/remove command as well?
+
+## 5. Clarify uncertainty quickly
+
+- If no exact skill exists, do you want the closest match or only exact fits?
+- If the catalog has no strong match, should I suggest the next best action instead?
+
+## Good intake pattern
+
+Good follow-up questions are:
+
+- short
+- task-focused
+- enough to narrow the catalog without starting a long interview
+
+Prefer one or two questions first. Ask more only if the answer still leaves the target skill ambiguous.


### PR DESCRIPTION
Add an experimental MCP-backed skills discovery skill that routes user requests through the Fusion skills index and returns actionable next-step guidance.

- Detect query, install, update, and remove intent before calling the skills MCP tool
- Preserve advisory lifecycle commands exactly when MCP returns them
- Allow GitHub MCP, shell listing, and GraphQL-backed discovery fallback when Fusion MCP is unavailable
- Add a follow-up question bank for vague requests so discovery can narrow to the right skill before searching
- Place the first iteration in the experimental skill lane
- Require explicit low-confidence handling instead of guessed matches

ref equinor/fusion-core-tasks#412