### PR TITLE
fix(skills): require Bip Bop title prefix in dependency review output

### DIFF
--- a/.changeset/fix-dependency-review-title-prefix.md
+++ b/.changeset/fix-dependency-review-title-prefix.md
@@ -1,0 +1,8 @@
+---
+"fusion-dependency-review": patch
+---
+
+Require the dependency review research and verdict outputs to use the Bip Bop title prefix.
+
+- align the advisor guidance with the required PR comment title format
+- update the research and verdict templates to start with the Bip Bop heading prefix

--- a/skills/.experimental/fusion-dependency-review/agents/research-advisor.md
+++ b/skills/.experimental/fusion-dependency-review/agents/research-advisor.md
@@ -37,7 +37,7 @@ Prefer portable, source-backed signals in this order:
 6. Record breaking changes, deprecations, and migration steps.
 7. Look for known regressions or open issues against the target version.
 8. Capture notable transitive dependency changes visible in the diff.
-9. Draft findings into the research template with explicit sources, discussion context, and unknowns, then prepare the same content as a PR-comment-ready research checkpoint.
+9. Draft findings into the research template with explicit sources, discussion context, and unknowns, then prepare the same content as a PR-comment-ready research checkpoint that keeps the exact title prefix format `# 🤖 Bip Bop - <title>`.
 
 ## Portable boundaries
 
@@ -62,6 +62,8 @@ Return:
 - Source list with enough detail to re-check the evidence
 - PR-comment-ready research checkpoint body
 - Explicit unknowns or missing evidence
+
+Use the exact title prefix format `# 🤖 Bip Bop - <title>` for the PR-comment-ready research checkpoint body.
 
 ## Guardrails
 

--- a/skills/.experimental/fusion-dependency-review/agents/verdict-advisor.md
+++ b/skills/.experimental/fusion-dependency-review/agents/verdict-advisor.md
@@ -28,7 +28,7 @@ Synthesize the research, security, code quality, and impact findings into one co
    - `medium`: no blocker exists, but at least one concern remains, impact is moderate, or source coverage is partial
    - `low`: major ambiguity, failing or unknown CI, missing release notes, or materially conflicting findings
 5. Make follow-up work explicit. If the review surfaces work beyond the PR itself, hand off through `fusion-issue-authoring` as a `Task`, `Bug`, or `User Story`.
-6. Produce a final PR-comment-ready verdict that summarizes the work done since the research checkpoint, the current validation state, and the requested maintainer action.
+6. Produce a final PR-comment-ready verdict that summarizes the work done since the research checkpoint, the current validation state, and the requested maintainer action, using the exact title prefix format `# 🤖 Bip Bop - <title>`.
 7. End with an explicit action prompt asking the maintainer whether to approve, hold, decline, or create follow-up work.
 
 ## Recommendation semantics
@@ -59,6 +59,8 @@ Return:
 - Handoff recommendation when needed
 - PR-comment-ready final verdict comment body
 - Explicit confirmation prompt
+
+Use the exact title prefix format `# 🤖 Bip Bop - <title>` for the PR-comment-ready final verdict comment body.
 
 ## Guardrails
 

--- a/skills/.experimental/fusion-dependency-review/assets/research-template.md
+++ b/skills/.experimental/fusion-dependency-review/assets/research-template.md
@@ -1,4 +1,4 @@
-# Dependency Update Research
+# 🤖 Bip Bop - Dependency Update Research
 
 Post this filled template to the PR as the research checkpoint comment before any branch mutation, rebase, push, approval, or merge.
 

--- a/skills/.experimental/fusion-dependency-review/assets/verdict-template.md
+++ b/skills/.experimental/fusion-dependency-review/assets/verdict-template.md
@@ -1,4 +1,4 @@
-# Dependency Update Verdict
+# 🤖 Bip Bop - Dependency Update Verdict
 
 ## Decision Snapshot
 

--- a/skills/.experimental/fusion-dependency-review/references/instructions.md
+++ b/skills/.experimental/fusion-dependency-review/references/instructions.md
@@ -32,7 +32,7 @@ Use this reference for the expanded execution contract. Keep `SKILL.md` focused 
 5. Capture notable transitive dependency changes visible in the diff.
 6. When the ecosystem provides audit tooling such as `npm audit`, `cargo audit`, or `pip-audit`, include that output as an additional evidence source.
 7. Start from `assets/review-tracker.md` and fill the context, discussion inventory, validation plan, and source inventory first.
-8. Draft detailed findings into `assets/research-template.md` either in `.tmp/` or as a PR comment draft.
+8. Draft detailed findings into `assets/research-template.md` either in `.tmp/` or as a PR comment draft, keeping the exact title prefix format `# 🤖 Bip Bop - <title>`.
 
 ## Step 3 — Run lens analysis and synthesize the verdict
 
@@ -48,7 +48,7 @@ Use this reference for the expanded execution contract. Keep `SKILL.md` focused 
 1. Post the research checkpoint comment before any source-control mutation, rebase, push, approval, or merge.
 2. If the runtime cannot post the research checkpoint comment, stop before mutation and tell the maintainer that the PR record could not be updated.
 3. Post the final verdict comment before any approval, hold, decline, or merge action. Refresh it with any patching or validation results before posting.
-4. Include the existing discussion summary, unresolved reviewer concerns or rationale for treating them as resolved or outdated, lens assessments, recommendation, confidence, follow-up items, and explicit confirmation prompt in the final verdict comment.
+4. Include the existing discussion summary, unresolved reviewer concerns or rationale for treating them as resolved or outdated, lens assessments, recommendation, confidence, follow-up items, and explicit confirmation prompt in the final verdict comment, and keep the exact title prefix format `# 🤖 Bip Bop - <title>`.
 5. If the runtime cannot post the final verdict comment, stop before approval or merge and tell the maintainer that the PR record could not be updated.
 6. If branch patching is required before approval or merge, use `agents/source-control-advisor.md` only after the verdict is accepted so branch-sync planning, rebase need, validation reruns, and push confirmation stay tied to the chosen next action.
 7. Before any rebase, push, force-push, approval, or merge, ask for explicit maintainer confirmation.


### PR DESCRIPTION
## Why

The dependency review skill needs a consistent PR-comment title format so its root skill page, research checkpoint output, and final verdict output all match the expected Bip Bop heading prefix everywhere they are defined.

## Current behavior

The skill referenced PR-comment-ready research and verdict outputs, but the root skill page, advisor guidance, and templates did not consistently surface the exact Bip Bop title format.

## New behavior

The dependency review root skill page, advisors, templates, and reference instructions now require the exact title prefix format `# 🤖 Bip Bop - <title>` for PR-comment-ready research and verdict outputs.

Validation run:

- `bun run biome:check`
- `npx -y skills add . --list`
- `bun run validate:skills`
- `bun run validate:ownership`
- `git diff --check`

## References

- Issue(s): none
- Related PR(s): none
- Docs / specs: none

## Reviewer focus

- Start here (files/areas): `skills/.experimental/fusion-dependency-review/SKILL.md`, `skills/.experimental/fusion-dependency-review/agents/`, `skills/.experimental/fusion-dependency-review/assets/`, `skills/.experimental/fusion-dependency-review/references/`, and `.changeset/fix-dependency-review-title-prefix.md`
- Verify these behavior changes: research and verdict outputs both require the same Bip Bop heading prefix in guidance and templates
- Risky or security-sensitive parts: none; this is a markdown-only skill guidance update

## Self review checklist

- [x] I scoped this PR to one clear purpose.
- [x] I followed [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I did not include secrets, credentials, or sensitive data.
- [x] I reviewed my own diff for clarity and unintended changes.