### PR TITLE
fix(skills): reduce GitHub GraphQL rate-limit risk in workflows

### DIFF
--- a/.changeset/reduce-discover-skills-graphql-cost.md
+++ b/.changeset/reduce-discover-skills-graphql-cost.md
@@ -1,0 +1,10 @@
+---
+"fusion-discover-skills": patch
+---
+
+Tighten GraphQL fallback guidance in discover-skills to minimize point cost and avoid retries on rate-limit errors.
+
+- Require small `first`/`last` values and shallow connections for catalog queries
+- Do not retry on rate-limit errors; surface the failure and suggest retrying later
+
+resolves equinor/fusion-core-tasks#535

--- a/.changeset/reduce-issue-authoring-api-calls.md
+++ b/.changeset/reduce-issue-authoring-api-calls.md
@@ -1,0 +1,12 @@
+---
+"fusion-issue-authoring": patch
+---
+
+Reduce token-heavy issue authoring behaviors by tightening MCP-first mutation sequencing and fallback guidance.
+
+- Replace redundant two-pass issue update guidance with single-call-first `issue_write` sequencing
+- Clarify cache-first behavior for labels and issue types to avoid repeated lookups
+- Add explicit rate-limit handling guidance that avoids retry loops and preserves local draft state
+- Tighten duplicate-search guidance to one focused pass unless scope changes
+
+resolves equinor/fusion-core-tasks#535

--- a/.changeset/reduce-issue-solving-api-retries.md
+++ b/.changeset/reduce-issue-solving-api-retries.md
@@ -1,0 +1,12 @@
+---
+"fusion-issue-solving": patch
+---
+
+Improve issue-solving workflow reliability under GitHub API limits by documenting a low-token execution strategy.
+
+- Require reuse of fetched issue context instead of repeated reads
+- Add MCP-first guidance for issue workflow mutations and lookups
+- Add explicit no-retry-loop behavior for rate-limit failures
+- Extend the workflow checklist with token-usage and fallback controls
+
+resolves equinor/fusion-core-tasks#535

--- a/.changeset/reduce-review-resolution-graphql-cost.md
+++ b/.changeset/reduce-review-resolution-graphql-cost.md
@@ -1,0 +1,11 @@
+---
+"fusion-github-review-resolution": patch
+---
+
+Add GraphQL cost awareness section to review-resolution skill to enforce conservative mutation pacing and secondary rate-limit handling.
+
+- Document per-mutation secondary cost (5 points) and per-query cost (1 point)
+- Require at least 1-second pause between consecutive GraphQL mutation calls
+- Require respect for `retry-after` headers before retrying on rate-limit errors
+
+resolves equinor/fusion-core-tasks#535

--- a/skills/.experimental/fusion-discover-skills/SKILL.md
+++ b/skills/.experimental/fusion-discover-skills/SKILL.md
@@ -85,6 +85,7 @@ Main workflow:
    - Prefer GitHub MCP repository or search tools when they are available in the current client.
    - Otherwise use read-only shell-based inspection against trusted sources only, such as `npx skills add --list <source>`, local `skills/**/SKILL.md` searches, `gh search code`, or `gh api graphql` against the catalog repository.
    - Use GraphQL only when structured repository data is needed and the higher-level MCP or search tools do not expose it cleanly.
+   - GraphQL read queries cost at least 1 point; keep `first`/`last` small and avoid nested connections to minimize point cost. Do not retry on rate-limit errors; surface the failure and suggest retrying later.
    - Treat GitHub-derived lifecycle guidance as fallback guidance unless Fusion MCP returned an explicit advisory command.
    - Never use remote-script execution patterns or shell pipelines that execute fetched content.
 6. Do one refinement pass when the first result set is weak.

--- a/skills/.experimental/fusion-github-review-resolution/SKILL.md
+++ b/skills/.experimental/fusion-github-review-resolution/SKILL.md
@@ -165,6 +165,16 @@ Use GitHub MCP tools for high-level PR operations and any dedicated review-threa
 
 > **Pro tip:** See each `.graphql` file in assets for complete mutation/query syntax and parameter names.
 
+### GraphQL cost awareness
+
+Review-resolution workflows make multiple GraphQL mutation calls (reply + resolve per thread). Be conservative:
+
+- Mutations cost 5 secondary-limit points each (vs 1 for read queries). Budget accordingly when processing many threads.
+- Pause at least 1 second between consecutive mutation calls to avoid secondary rate limits.
+- Keep `first`/`last` connection arguments small (prefer `first: 100` only when you need all threads in a single page).
+- If a secondary rate-limit error or `retry-after` header is returned, stop processing and respect the indicated wait before retrying.
+- Always prefer a dedicated MCP review-thread tool over raw GraphQL when the client exposes one.
+
 ## Expected output
 
 Return a concise report containing:

--- a/skills/.experimental/fusion-issue-solving/SKILL.md
+++ b/skills/.experimental/fusion-issue-solving/SKILL.md
@@ -66,32 +66,41 @@ Optional inputs:
    - If yes, use/create the worktree and continue there.
 
 2. Confirm issue context and success criteria
-   - Read the issue body, labels, and linked discussions.
+   - Read the issue body, labels, and linked discussions once, then reuse that context instead of refetching.
    - Restate the implementable scope and explicitly list out-of-scope items.
 
 3. Confirm assignee intent for issue closure work
    - Check whether the current user is assigned to the primary issue.
    - If the current user is not assigned, ask whether they want to assign themselves before continuing.
-   - For each sub-issue that will be resolved or closed by this workflow, check assignee status.
+   - For each sub-issue that will be resolved or closed by this workflow, check assignee status once and reuse the result for closure decisions.
    - If the current user is not assigned on a sub-issue, ask whether they want to assign themselves before resolving/closing it.
 
-4. Build and track a concrete plan
+4. Apply low-token GitHub strategy
+   - Prefer MCP-backed tools over ad hoc `gh api` or GraphQL calls when equivalent tools exist.
+   - Avoid duplicate lookups for labels, issue types, and duplicate detection.
+   - Cache per-run context (issue metadata, duplicate matches, issue-type support) and reuse it.
+   - Use GraphQL fallback only when MCP coverage is unavailable and do not loop retries.
+   - GraphQL mutations cost 5 secondary-limit points each (vs 1 for queries); batch fields into single calls and pause at least 1 second between mutation calls.
+   - Respect `retry-after` and `x-ratelimit-reset` headers; do not retry before the indicated wait.
+   - If rate limits are hit, stop non-essential operations and continue with local implementation/PR preparation when possible.
+
+5. Build and track a concrete plan
    - Create actionable todos ordered by dependencies.
    - Keep exactly one step in progress and update status as work completes.
 
-5. Research before edits
+6. Research before edits
    - Inspect relevant files, tests, and adjacent usage.
    - Prefer root-cause fixes over surface patches.
 
-6. Implement in small scoped changes
+7. Implement in small scoped changes
    - Keep each change aligned to issue acceptance criteria.
    - Avoid unrelated refactors and generated release artifacts.
 
-7. Validate incrementally
+8. Validate incrementally
    - Run targeted checks first, then required project checks.
    - If checks fail, fix relevant issues and re-run before proceeding.
 
-8. Prepare PR-ready output
+9. Prepare PR-ready output
    - Summarize what changed and why.
    - Include validation evidence and known follow-ups.
    - Draft the PR body in a `.tmp/` file with an issue/context-specific name (for example, `.tmp/pr-body-issue-123-scope-summary.md`), not a shared `.tmp/pr-body.md`.
@@ -100,9 +109,11 @@ Optional inputs:
    - Ask whether the PR should be opened as draft or ready for review.
    - Ask whether the PR should be assigned to the user and whether related issues should be linked.
 
-9. Optional GitHub mutation steps
+10. Optional GitHub mutation steps
    - Before any GitHub mutation (create/edit/comment/close), ask for explicit user confirmation.
    - If requested, update issue status/comments with objective progress.
+   - Prefer MCP tool mutations over ad hoc API calls when equivalent operations exist.
+   - If GitHub API rate limits block mutation, report the failure clearly, stop retry loops, and propose a safe retry sequence.
    - If requested, create or update the PR using the repository PR template and the `.tmp/` PR body draft file, using the confirmed base branch, draft/ready state, assignee choice, and related issue links.
 
 ## Expected output
@@ -112,6 +123,7 @@ Return a concise delivery report with:
 - files changed,
 - validation commands and outcomes,
 - assignment decisions for primary issue and affected sub-issues,
+- API usage strategy used (MCP-first/cache reuse/fallbacks),
 - open risks/blockers,
 - PR body summary (or `.tmp/` draft file path when created).
 

--- a/skills/.experimental/fusion-issue-solving/assets/issue-solving-checklist.md
+++ b/skills/.experimental/fusion-issue-solving/assets/issue-solving-checklist.md
@@ -6,6 +6,9 @@ Use this checklist while executing the issue-solving workflow.
 | --- | --- |
 | [ ] Confirm issue scope and out-of-scope | |
 | [ ] Decide branch/worktree strategy | |
+| [ ] Capture issue metadata once and reuse | |
+| [ ] Prefer MCP tools and avoid redundant API lookups | |
+| [ ] Define rate-limit fallback plan (no retry loops) | |
 | [ ] Build actionable todo plan | |
 | [ ] Inspect relevant code/tests/docs | |
 | [ ] Implement scoped changes | |

--- a/skills/fusion-issue-authoring/SKILL.md
+++ b/skills/fusion-issue-authoring/SKILL.md
@@ -62,7 +62,7 @@ Collect before publishing:
 - Issue intent/context
 - Issue type (Bug, Feature, User Story, Task)
 - Existing issue number/url when updating
-- Repository label set (or confirmation that labels are intentionally skipped)
+- Repository label set (or confirmation that labels are intentionally skipped). Reuse cached label results per repository within the same session.
 - Parent/related issue links and dependency direction (sub-issue vs blocking)
 - Assignee preference (assign to user, specific person, or leave unassigned)
 
@@ -90,7 +90,8 @@ If ambiguous, ask only essential clarifying questions.
 
 ### Step 3 — Check duplicates
 
-Search for likely duplicates with `mcp_github::search_issues` and surface matches before drafting/publishing.
+Run one focused duplicate search with `mcp_github::search_issues` and surface matches before drafting/publishing.
+Do not run repeated broad duplicate scans unless the user changes scope/title materially.
 
 ### Step 4 — Draft first
 
@@ -111,21 +112,29 @@ Before mutation, confirm:
 ### Step 7 — Mutate via MCP (ordered)
 
 After explicit confirmation, execute MCP mutations in this order:
-1. `mcp_github::issue_write` create/update (include `type` only when supported)
-2. `mcp_github::issue_write` labels / assignees
-3. `mcp_github::sub_issue_write` relationships and execution ordering
-4. `mcp_github::add_issue_comment` for blocker/status notes when requested
+1. `mcp_github::issue_write` create/update with the full known payload (`title`, `body`, and include `labels`, `assignees`, `type` only when supported)
+2. Optional single follow-up `mcp_github::issue_write` only when required fields were unknown in step 1 and become available later
+3. `mcp_github::sub_issue_write` only when relationship/order changes are requested
+4. `mcp_github::add_issue_comment` only when blocker/status notes are explicitly requested
 
 If mutation fails due to missing MCP server/auth/config:
 - explain the failure clearly
 - guide user to setup steps in `references/mcp-server.md`
 - retry after user confirms setup is complete
 
+Rate-limit behavior:
+- Detect and report rate-limit failures clearly (`API rate limit exceeded`, `secondary rate limit`, GraphQL quota exhaustion).
+- Stop non-essential lookups and skip optional enrichments when rate limits are hit.
+- Keep draft artifacts and return a safe retry plan instead of looping retries.
+- Prefer MCP tools over ad hoc `gh api`/GraphQL retries when equivalent MCP capability exists.
+- When using GraphQL fallback: mutations cost 5 secondary-limit points each (vs 1 for queries), so batch fields into a single mutation call and pause at least 1 second between mutation calls.
+- Respect `retry-after` and `x-ratelimit-reset` headers before retrying any request.
+
 `type` rule:
 - Only use `type` if the repository has issue types configured.
 - Use cached issue types per organization when available.
 - Call `mcp_github::list_issue_types` only on cache miss or invalid cache.
-- If issue types are not supported, omit `type`.
+- If issue types are not supported, omit `type` for the rest of the session.
 
 ### Step 8 — Validate relationships
 

--- a/skills/fusion-issue-authoring/assets/graphql/README.md
+++ b/skills/fusion-issue-authoring/assets/graphql/README.md
@@ -21,3 +21,23 @@ When running these files via `gh api graphql`, include:
 without this header, issue type and sub-issue fields may fail schema validation.
 
 Prefer MCP tools first when available; use these files as explicit fallback.
+
+## GraphQL cost awareness
+
+GitHub GraphQL rate limits (https://docs.github.com/en/graphql/overview/rate-limits-and-query-limits-for-the-graphql-api):
+
+- **Primary budget**: 5,000 points/hour per user (10,000 for GitHub Enterprise Cloud). Each query costs at least 1 point; nested connections multiply.
+- **Secondary limits**: mutations cost 5 points, read queries cost 1 point. Max 2,000 points/minute. Max 100 concurrent requests. Max 60 seconds GraphQL CPU time per 60 seconds real time.
+- **Content creation cap**: max 80 content-generating requests/minute, 500/hour.
+- **Timeouts**: requests exceeding 10 seconds are terminated and deduct additional points from the hourly budget.
+- **Node limit**: max 500,000 nodes per call; `first`/`last` must be 1–100. Keep connection page sizes small (prefer `first: 10` or `first: 20` over `first: 100`) unless you need bulk data.
+
+## Fallback guardrails
+
+- Run only the minimum GraphQL file required for the current missing capability.
+- Reuse ids returned from prior responses instead of repeating lookup queries.
+- Do not execute retry loops for GraphQL failures.
+- Pause at least 1 second between consecutive mutation calls.
+- Keep `first`/`last` arguments small to reduce point cost and avoid timeouts.
+- If rate limits are hit (`x-ratelimit-remaining: 0` or `retry-after` header present), stop optional fallback operations, respect the reset/retry-after window, and return a clear retry plan.
+- Switch back to MCP tools immediately when equivalent MCP coverage is available.

--- a/skills/fusion-issue-authoring/references/instructions.md
+++ b/skills/fusion-issue-authoring/references/instructions.md
@@ -9,6 +9,16 @@ Goal: create clear GitHub issues fast, with draft-first review and safe mutation
 - Never mutate before explicit publish confirmation.
 - Ask only essential clarifying questions.
 - Resolve repository and labels before mutation.
+- Prefer MCP tools first and avoid ad hoc GitHub API/GraphQL retries when an MCP equivalent exists.
+
+## Low-token strategy
+
+- Fetch required context once and reuse it through the run.
+- Run one focused duplicate check; avoid repeated broad searches.
+- Query labels only when labels are needed for the current mutation.
+- Cache issue types per organization and skip repeated `list_issue_types` calls on cache hit.
+- Run sub-issue mutations only for relationships that actually changed.
+- If rate limits are hit, stop optional lookups and return a clear retry plan.
 
 ## Workflow
 
@@ -22,9 +32,10 @@ Goal: create clear GitHub issues fast, with draft-first review and safe mutation
 6. Review with user and apply edits.
 7. Ask explicit publish confirmation.
 8. Mutate via MCP in this order:
-	- `mcp_github::issue_write` create/update (labels/assignees included as needed)
-	- `mcp_github::sub_issue_write` for sub-issue ordering/links
-	- `mcp_github::add_issue_comment` for blocker/status notes when requested
+	- `mcp_github::issue_write` create/update with full known payload (labels/assignees/type when supported)
+	- optional single follow-up `mcp_github::issue_write` only for fields unavailable in the first call
+	- `mcp_github::sub_issue_write` for sub-issue ordering/links only when changes are needed
+	- `mcp_github::add_issue_comment` for blocker/status notes only when requested
 
 MCP failure handling:
 - If mutation fails due to missing MCP server/auth/config, explain the failure clearly.
@@ -35,7 +46,14 @@ Type parameter rule:
 - Use cached issue types for the organization when available.
 - Call `mcp_github::list_issue_types` only on cache miss (or when cache is invalid).
 - Send `type` only when the repository supports issue types.
-- Omit `type` when issue types are unsupported.
+- Omit `type` when issue types are unsupported and treat that owner as unsupported for the rest of the session.
+
+Rate-limit fallback:
+- Detect and surface rate-limit failures clearly.
+- Do not retry in tight loops; respect `retry-after` and `x-ratelimit-reset` headers.
+- GraphQL mutations cost 5 secondary-limit points each; minimize separate mutation calls.
+- Pause at least 1 second between consecutive GraphQL mutation calls.
+- Preserve local drafts in `.tmp/` and provide a safe retry path for the user.
 
 ## Task mode
 

--- a/skills/fusion-issue-authoring/references/mcp-server.md
+++ b/skills/fusion-issue-authoring/references/mcp-server.md
@@ -13,6 +13,22 @@ Use this file for GitHub MCP-specific tools and payload examples.
 - `mcp_github::add_issue_comment`: add comment to issue.
 - `mcp_github::list_issue_types`: list available issue types.
 
+## High-cost operations and mitigation
+
+Common expensive paths in issue workflows:
+
+- repeated `list_issue_types` calls per issue,
+- repeated duplicate searches with broad queries,
+- unnecessary second-pass issue updates for labels/assignees,
+- GraphQL fallback retries that loop on rate-limit errors.
+
+Mitigation policy:
+
+- cache issue types per owner for the active session,
+- run one focused duplicate search unless scope materially changes,
+- send full known issue payload in the first `issue_write` call,
+- run GraphQL fallback only when MCP coverage is missing and without retry loops.
+
 ## MCP readiness check
 
 Run a read-only probe before issue authoring:
@@ -81,6 +97,12 @@ Optional local cache file for longer runs:
 - `.tmp/issue-type-cache.json` (never committed)
 - refresh when owner changes or validation fails.
 
+## Duplicate search minimization
+
+- Prefer one focused query that combines key title terms and repository scope.
+- Reuse the same duplicate search result set throughout draft review unless the problem statement changes.
+- Avoid broad repeated searches after mutation failures; resolve auth/config first.
+
 ## Example props
 
 ### Create a Task issue
@@ -145,7 +167,28 @@ Use either `after_id` or `before_id` for reprioritization.
 
 ## Minimal task-batch order
 
-1. `mcp_github::issue_write` create
-2. `mcp_github::issue_write` set labels/type/assignee
-3. `mcp_github::sub_issue_write` add/reprioritize children in execution order
-4. Optional: `mcp_github::add_issue_comment` to record blocker context
+1. `mcp_github::issue_write` create/update with full known fields (`title`, `body`, `labels`, `assignees`, optional `type`)
+2. Optional single follow-up `mcp_github::issue_write` only for fields that were unavailable in step 1
+3. `mcp_github::sub_issue_write` add/reprioritize children in execution order only when linkage changed
+4. Optional: `mcp_github::add_issue_comment` to record blocker context when requested
+
+## Rate-limit fallback behavior
+
+GitHub GraphQL limits (summary from https://docs.github.com/en/graphql/overview/rate-limits-and-query-limits-for-the-graphql-api):
+
+| Limit | Value |
+|---|---|
+| Primary budget | 5,000 pts/hour per user (1,000 for `GITHUB_TOKEN` in Actions) |
+| Mutation secondary cost | 5 pts per GraphQL mutation, 1 pt per read query |
+| Secondary throughput | max 2,000 pts/minute; max 80 content-creating requests/minute |
+| Concurrency | max 100 concurrent requests (shared REST + GraphQL) |
+| Timeout | 10 s per request; timeout deducts extra points |
+
+Behavior when limits are approached or hit:
+
+- Check `x-ratelimit-remaining` and `retry-after` headers; respect the reset window.
+- Stop optional enrichments and avoid automatic retry loops.
+- Pause at least 1 second between consecutive mutation calls.
+- Preserve draft state and return a clear retry sequence to the user.
+- Prefer MCP calls over ad hoc GraphQL retries when equivalent MCP tools are available.
+- Never retry a request that returned a secondary rate-limit error without waiting for the `retry-after` period.


### PR DESCRIPTION
## Why

Issue-authoring and issue-solving workflows were making repeated GraphQL and API lookups, increasing the risk of GitHub rate-limit failures during normal use.

This PR makes those workflows explicitly conservative by default and documents concrete limits/behaviors to reduce token burn and retry storms.

## Current behavior

- Skills documented MCP-first intent, but GraphQL fallback behavior was still loosely specified in several places.
- Some guidance did not include concrete cost/limit numbers or explicit wait behavior for `retry-after` / `x-ratelimit-reset`.
- GraphQL-heavy workflows (for example review-thread resolution) did not clearly require conservative mutation pacing.

## New behavior

- Adds explicit low-token strategy for issue workflows:
  - cache-and-reuse fetched context,
  - avoid repeated broad duplicate/metadata lookups,
  - use one-pass-first issue mutation payloads,
  - no tight retry loops on rate-limit errors.
- Adds concrete GitHub GraphQL constraints and guidance:
  - primary/secondary limit awareness,
  - mutation/query point-cost differences,
  - 1-second spacing between mutation calls,
  - header-based retry gating (`retry-after`, `x-ratelimit-reset`),
  - conservative connection sizing and timeout/node-limit awareness.
- Extends this guidance across the issue-authoring, issue-solving, review-resolution, and discover-skills paths.

## References

- Issue(s):
  - resolves equinor/fusion-core-tasks#535
  - related to equinor/fusion-core-tasks#362
- Related PR(s):
  - n/a
- Docs / specs:
  - https://docs.github.com/en/graphql/overview/rate-limits-and-query-limits-for-the-graphql-api

## Reviewer focus

- Start here (files/areas):
  - skills/fusion-issue-authoring/SKILL.md
  - skills/fusion-issue-authoring/references/instructions.md
  - skills/fusion-issue-authoring/references/mcp-server.md
  - skills/fusion-issue-authoring/assets/graphql/README.md
  - skills/.experimental/fusion-issue-solving/SKILL.md
  - skills/.experimental/fusion-github-review-resolution/SKILL.md
  - skills/.experimental/fusion-discover-skills/SKILL.md
  - .changeset/*.md entries for each touched skill
- Verify these behavior changes:
  - GraphQL fallback remains explicit fallback only,
  - rate-limit handling is stop-and-wait (not retry-loop),
  - mutation pacing and conservative query guidance are clearly documented.
- Risky or security-sensitive parts:
  - No runtime code changes; this PR is documentation/policy guidance only.

## Self review checklist

- [x] I scoped this PR to one clear purpose.
- [x] I followed [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I did not include secrets, credentials, or sensitive data.
- [x] I reviewed my own diff for clarity and unintended changes.
