### PR TITLE
feat(skill): add fusion framework feature toggling skill

### DIFF
--- a/.changeset/fusion-framework-feature-toggling-skill.md
+++ b/.changeset/fusion-framework-feature-toggling-skill.md
@@ -1,0 +1,14 @@
+---
+"fusion-framework-feature-toggling": minor
+---
+
+Add the experimental `fusion-framework-feature-toggling` skill for Fusion Framework feature-flag guidance.
+
+- prefer Fusion MCP retrieval when the local framework index is available
+- fall back to bundled public-source references when Fusion MCP is unavailable or weak
+- add offline assets for implementation prompts and review checklists when users do not have the server
+- anchor the guidance to current public Fusion Framework surfaces such as `enableFeatureFlag`, `enableFeatureFlagging`, `useFeature`, and the feature-flag plugins
+- call out current public-source ambiguity like `readonly` vs `readOnly` instead of inventing API details
+
+Related to: equinor/fusion-core-tasks#362
+resolves equinor/fusion-core-tasks#740

--- a/skills/.experimental/fusion-framework-feature-toggling/SKILL.md
+++ b/skills/.experimental/fusion-framework-feature-toggling/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: fusion-framework-feature-toggling
+description: 'Guides developers using Fusion Framework feature flags with MCP-backed framework retrieval first and bundled public-source fallback assets when MCP is unavailable. USE FOR: helping with `enableFeatureFlag`, `enableFeatureFlagging`, `useFeature`, rollout/cleanup guidance, and finding Fusion Framework feature-flag examples. DO NOT USE FOR: generic SaaS flag platforms, backend-only rollout systems, or inventing framework APIs.'
+license: MIT
+compatibility: Works best with Fusion MCP access via `mcp_fusion_search_framework` or `mcp_fusion_search_docs`. When Fusion MCP is unavailable, this skill falls back to bundled public-source references and offline assets.
+metadata:
+  version: "0.0.0"
+  status: experimental
+  owner: "@equinor/fusion-core"
+  tags:
+    - fusion
+    - framework
+    - feature-flag
+    - feature-toggle
+    - mcp
+    - guidance
+  mcp:
+    suggested:
+      - mcp_fusion
+---
+
+# Fusion Framework Feature Toggling
+
+## When to use
+
+Use this skill when a developer needs grounded help with feature toggling in Fusion Framework.
+
+Typical triggers:
+- "Help me add a feature flag to a Fusion Framework app"
+- "How do I use useFeature in Fusion Framework?"
+- "Which Fusion Framework feature-flag API should I use here?"
+- "Review this Fusion feature toggle setup"
+- "How should I roll out and later remove this Fusion feature flag?"
+
+## When not to use
+
+Do not use this skill for:
+- generic LaunchDarkly or SaaS flag-platform setup
+- backend-only rollout systems outside Fusion Framework
+- inventing a new feature-toggle architecture without framework evidence
+- non-Fusion React or frontend flagging guidance
+
+## Required inputs
+
+Collect before responding:
+- whether the work is app-level or framework-level
+- the developer's goal: add, review, debug, roll out, or remove a flag
+- the intended feature key or feature description
+- whether the flag needs persistence, URL control, or a typed value
+- any current code context that should be adapted
+
+If important inputs are missing, ask only the smallest question needed to choose the right framework surface.
+
+## Instructions
+
+1. Confirm the request is really about Fusion Framework feature toggling.
+   - If the request is generic flag-platform work, do not force this skill.
+
+2. Use Fusion MCP first when it is available.
+   - Query `mcp_fusion_search_framework` with the user's wording plus feature-toggle terms such as `feature flag`, `feature toggling`, `useFeature`, `enableFeatureFlag`, or `enableFeatureFlagging`.
+   - If the first result set is weak, do one refinement pass.
+   - Use `mcp_fusion_search_docs` only when broader product guidance is needed beyond framework implementation details.
+
+3. If Fusion MCP is unavailable or inconclusive, say so clearly and switch to the bundled fallback.
+   - Use [references/public-framework-reference.md](references/public-framework-reference.md) as the fallback source of truth.
+   - Use [assets/offline-feature-toggle-checklist.md](assets/offline-feature-toggle-checklist.md) and [assets/offline-prompt-template.md](assets/offline-prompt-template.md) for users who do not have the server.
+
+4. Identify which help shape the user needs.
+   - New flag setup: explain the configuration surface and show a minimal example.
+   - Component usage: explain `useFeature`, toggle behavior, and value handling.
+   - Review or rollout: apply the checklist and point out missing ownership, testing, or cleanup.
+   - Removal: identify the flag definition, consumers, and dead branches that should be deleted together.
+
+5. Prefer the currently evidenced Fusion Framework entry points.
+   - App-level example: `enableFeatureFlag(appConfigurator, [...])` from `@equinor/fusion-framework-react-app/feature-flag`.
+   - Framework-level example: `enableFeatureFlagging(config, builder => ...)` from `@equinor/fusion-framework-module-feature-flag`.
+   - Plugin examples: `createLocalStoragePlugin` and `createUrlPlugin`.
+   - Hook usage: `useFeature(key)` in the app package, or the provider-based `useFeature(provider, key)` variant in the framework package.
+
+6. Call out public-source ambiguity instead of guessing.
+   - Public sources currently show both `readonly` and `readOnly`; tell the user to verify the local type before finalizing code.
+   - Public docs mention a future API-service direction for feature flags; do not present that as the current default unless live MCP or local code confirms it.
+
+7. Give practical guidance, not just API names.
+   - Prefer stable enum or constant keys over ad hoc string literals.
+   - Include `title` and `description` when the flag is surfaced to users or reviewers.
+   - Use `value` only when behavior needs configuration in addition to on/off state.
+   - Keep flags easy to remove, define an owner, and call out the cleanup trigger.
+   - Distinguish local app toggles from framework-wide or plugin-backed toggles.
+
+8. Return a concise, evidence-backed answer.
+   - State whether the guidance came from Fusion MCP or the bundled fallback.
+   - Include the relevant package names and one concrete snippet or source path.
+   - Include rollout, testing, and cleanup guidance.
+   - End with any explicit uncertainty or verification step that still remains.
+
+## Representative requests
+
+- "Help me add a feature flag to a Fusion Framework app."
+- "How do I use useFeature in Fusion Framework?"
+- "Review this Fusion Framework feature toggle setup and tell me what cleanup I am missing."
+
+## Expected output
+
+Return:
+- whether the guidance came from Fusion MCP or the bundled fallback
+- the relevant Fusion Framework entry points and packages
+- one concrete example snippet or source path to adapt
+- a short implementation, rollout, and cleanup checklist
+- explicit verification notes for any ambiguous API detail
+
+## References
+
+- [references/public-framework-reference.md](references/public-framework-reference.md)
+
+## Assets
+
+- [assets/offline-feature-toggle-checklist.md](assets/offline-feature-toggle-checklist.md)
+- [assets/offline-prompt-template.md](assets/offline-prompt-template.md)
+
+## Safety & constraints
+
+Never:
+- invent Fusion Framework packages, hooks, or module names
+- pretend Fusion MCP results exist when the server is unavailable
+- generalize SaaS feature-flag advice as if it were Fusion Framework behavior
+- keep flags alive without calling out ownership and cleanup
+
+Always:
+- prefer Fusion MCP first, then the bundled public-source fallback
+- separate confirmed framework APIs from general rollout guidance
+- call out API or version ambiguity when public sources disagree
+- keep examples small and easy to adapt

--- a/skills/.experimental/fusion-framework-feature-toggling/assets/README.md
+++ b/skills/.experimental/fusion-framework-feature-toggling/assets/README.md
@@ -1,0 +1,8 @@
+# Feature-toggle assets
+
+Assets for `fusion-framework-feature-toggling`.
+
+## Files
+
+- `offline-feature-toggle-checklist.md` - offline implementation and review checklist for environments without Fusion MCP
+- `offline-prompt-template.md` - reusable prompt template for grounded no-server help

--- a/skills/.experimental/fusion-framework-feature-toggling/assets/offline-feature-toggle-checklist.md
+++ b/skills/.experimental/fusion-framework-feature-toggling/assets/offline-feature-toggle-checklist.md
@@ -1,0 +1,45 @@
+# Offline Feature-Toggle Checklist
+
+Use this checklist when Fusion MCP is unavailable and you still need grounded guidance for a Fusion Framework feature flag.
+
+## Scope choice
+
+- [ ] Confirm the request is really about Fusion Framework feature toggling.
+- [ ] Decide whether the work is app-level or framework-level.
+- [ ] Choose the likely entry point:
+  - app-level: `enableFeatureFlag`
+  - framework-level: `enableFeatureFlagging`
+
+## Flag definition
+
+- [ ] Define a stable key, preferably in an enum or shared constant.
+- [ ] Add a human-readable `title`.
+- [ ] Add a `description` when the flag will be surfaced in UI or review discussions.
+- [ ] Decide whether the flag needs a typed `value` in addition to enabled or disabled.
+- [ ] Verify whether the local code expects `readonly` or `readOnly` before committing the flag shape.
+
+## Toggle source and behavior
+
+- [ ] Decide whether the flag is local to the app or should participate in framework-level providers.
+- [ ] If toggle state should persist locally, inspect `createLocalStoragePlugin`.
+- [ ] If query-string toggling is useful, inspect `createUrlPlugin`.
+- [ ] If the flag should not be user-togglable, verify the local read-only property name.
+
+## Component usage
+
+- [ ] Read the flag through `useFeature` instead of duplicating toggle state.
+- [ ] Handle the disabled path explicitly.
+- [ ] Handle missing feature data safely with null checks.
+- [ ] If the flag exposes a `value`, test both enabled and disabled rendering paths.
+
+## Rollout and cleanup
+
+- [ ] Record an owner for the flag.
+- [ ] State what event or milestone should remove the flag.
+- [ ] Test the application with the flag both on and off.
+- [ ] Remove the flag definition, consumers, and dead branches together when the rollout ends.
+
+## Fallback evidence path
+
+If you need a public-source refresher while still offline, start with:
+- `references/public-framework-reference.md`

--- a/skills/.experimental/fusion-framework-feature-toggling/assets/offline-prompt-template.md
+++ b/skills/.experimental/fusion-framework-feature-toggling/assets/offline-prompt-template.md
@@ -1,0 +1,34 @@
+# Offline Prompt Template
+
+Use this template when Fusion MCP is unavailable and you want grounded Copilot help with a Fusion Framework feature flag.
+
+```md
+I need help with feature toggling in Fusion Framework.
+
+Goal:
+- add / review / remove a feature flag for: <feature description>
+
+Current layer:
+- app-level (`@equinor/fusion-framework-react-app/feature-flag`)
+- framework-level (`@equinor/fusion-framework-module-feature-flag`)
+- not sure yet
+
+Current code or target file:
+```ts
+<paste the relevant config, hook usage, or component code>
+```
+
+Questions to answer:
+- Should this use `enableFeatureFlag` or `enableFeatureFlagging`?
+- Where should the feature key live?
+- Do I need local storage or URL plugin support?
+- How should I consume this through `useFeature`?
+- What rollout, ownership, and cleanup steps should I plan?
+
+Constraints:
+- <package/version constraints>
+- <testing constraints>
+- <rollout or cleanup deadline>
+
+Please ground the answer in Fusion Framework feature-flag APIs and call out any ambiguity that I should verify locally.
+```

--- a/skills/.experimental/fusion-framework-feature-toggling/references/public-framework-reference.md
+++ b/skills/.experimental/fusion-framework-feature-toggling/references/public-framework-reference.md
@@ -1,0 +1,136 @@
+# Public Fusion Framework Feature-Flag Reference
+
+Use this reference when Fusion MCP is unavailable or too weak to answer the user's question.
+
+This file intentionally stays grounded in public `equinor/fusion-framework` sources that were easy to inspect during authoring. It is a fallback reference, not a promise that every API name is unchanged in the user's local version.
+
+## Confirmed public surfaces
+
+### App-level configuration
+
+The public feature-flag cookbook shows app-level configuration through:
+
+```ts
+import { enableFeatureFlag } from '@equinor/fusion-framework-react-app/feature-flag';
+
+export const configure: AppModuleInitiator = (appConfigurator) => {
+  enableFeatureFlag(appConfigurator, [
+    {
+      key: Feature.Basic,
+      title: 'Basic',
+    },
+  ]);
+};
+```
+
+Observed in the public repository:
+- `cookbooks/app-react-feature-flag/src/config.ts`
+
+### Framework-level configuration
+
+The public module documentation shows framework-level setup through:
+
+```ts
+import { enableFeatureFlagging } from '@equinor/fusion-framework-module-feature-flag';
+import {
+  createLocalStoragePlugin,
+  createUrlPlugin,
+} from '@equinor/fusion-framework-module-feature-flag/plugins';
+
+enableFeatureFlagging(config, (builder) => {
+  builder.addPlugin(createLocalStoragePlugin([{ key: 'fusionDebug', title: 'Fusion debug log' }]));
+  builder.addPlugin(createUrlPlugin(['fusionDebug']));
+});
+```
+
+Observed in the public repository:
+- `packages/modules/feature-flag/README.md`
+- `packages/dev-portal/src/config.ts`
+
+### Hook usage
+
+The public cookbook shows app-level usage through:
+
+```tsx
+import { useFeature } from '@equinor/fusion-framework-react-app/feature-flag';
+
+const basicFeature = useFeature(Feature.Basic);
+
+<Switch
+  checked={basicFeature.feature?.enabled}
+  onChange={() => basicFeature.toggleFeature()}
+/>
+```
+
+Observed in the public repository:
+- `cookbooks/app-react-feature-flag/src/FeatureFlags.tsx`
+
+The public framework package also exposes a provider-based hook shape:
+
+```ts
+useFeature(provider, key)
+```
+
+Observed in the public repository:
+- `packages/react/framework/src/feature-flag/useFeature.ts`
+
+### Useful feature properties
+
+Public sources show feature-flag objects using fields such as:
+- `key`
+- `title`
+- `description`
+- `enabled`
+- `value`
+- `source`
+
+Public examples also show a read-only flag property, but the spelling is inconsistent across sources. See caveats below.
+
+## Practical guidance anchored in the public sources
+
+Use the public evidence to help with these choices:
+
+1. App-local toggle with a small static list:
+   - Start from `enableFeatureFlag(appConfigurator, [...])`.
+
+2. Framework or shared-module toggle behavior with plugins:
+   - Start from `enableFeatureFlagging(config, builder => ...)`.
+   - Consider `createLocalStoragePlugin` when local persistence is desired.
+   - Consider `createUrlPlugin` when query-string toggling is desirable.
+
+3. Component consumption:
+   - Use `useFeature(key)` when working at the app package level.
+   - Read `feature?.enabled`, `feature?.description`, and optional typed `feature?.value`.
+   - Toggle through `toggleFeature()` or `toggleFeature(true | false)`.
+
+## Known caveats to surface explicitly
+
+### `readonly` vs `readOnly`
+
+Public sources are not perfectly aligned:
+- `cookbooks/app-react-feature-flag/src/config.ts` uses `readonly: true`
+- `cookbooks/app-react-feature-flag/src/FeatureFlags.tsx` reads `feature.readonly`
+- older public docs mention `readOnly`
+
+Do not guess which form is correct for the user's version. Tell them to confirm against local types or live Fusion MCP results before finalizing code.
+
+### Future API-service note
+
+Public docs mention a future direction where feature flags may be provided as an API service. Treat that as forward-looking context, not as the current default implementation path unless current local code or live MCP confirms it.
+
+## Public source map
+
+- Module docs:
+  - https://github.com/equinor/fusion-framework/blob/main/packages/modules/feature-flag/README.md
+- App guide:
+  - https://github.com/equinor/fusion-framework/blob/main/vue-press/src/guide/app/feature-flag.md
+- Cookbook:
+  - https://github.com/equinor/fusion-framework/tree/main/cookbooks/app-react-feature-flag
+- Example config:
+  - https://github.com/equinor/fusion-framework/blob/main/cookbooks/app-react-feature-flag/src/config.ts
+- Example component:
+  - https://github.com/equinor/fusion-framework/blob/main/cookbooks/app-react-feature-flag/src/FeatureFlags.tsx
+- App hook variant:
+  - https://github.com/equinor/fusion-framework/blob/main/packages/react/app/src/feature-flag/useFeature.ts
+- Framework hook variant:
+  - https://github.com/equinor/fusion-framework/blob/main/packages/react/framework/src/feature-flag/useFeature.ts


### PR DESCRIPTION
## Why

Add a focused Fusion skill for helping developers use feature toggling in Fusion Framework without forcing them to rediscover the framework surface each time.

The skill prefers Fusion MCP retrieval when the framework index is available, but it also ships offline fallback assets for users who do not have the server or cannot reach it.

## Current behavior

There is no dedicated skill in this repository for Fusion Framework feature toggling.

Developers currently have to piece guidance together from framework docs, cookbook examples, local code, or ad hoc prompts, which increases the risk of inconsistent setup, weak rollout guidance, and poor cleanup discipline.

## New behavior

Add a new experimental skill: `fusion-framework-feature-toggling`.

The skill now:
- prefers Fusion MCP retrieval first for current framework guidance
- falls back to bundled public-source references when Fusion MCP is unavailable or weak
- includes offline assets for users without the server
- points developers to evidenced Fusion Framework entry points such as `enableFeatureFlag`, `enableFeatureFlagging`, `useFeature`, and feature-flag plugins
- explicitly calls out public-source ambiguity such as `readonly` vs `readOnly` instead of guessing

## References

- Issue(s):
  - Refs: equinor/fusion-core-tasks#740
  - Related to: equinor/fusion-core-tasks#362
- Related PR(s):
  - None
- Docs / specs:
  - Public `equinor/fusion-framework` feature-flag module docs, guide, cookbook, and `useFeature` implementations

## Reviewer focus

- Start here (files/areas):
  - `skills/.experimental/fusion-framework-feature-toggling/SKILL.md`
  - `skills/.experimental/fusion-framework-feature-toggling/references/public-framework-reference.md`
  - `skills/.experimental/fusion-framework-feature-toggling/assets/`
  - `.changeset/fusion-framework-feature-toggling-skill.md`
- Verify these behavior changes:
  - the skill is discoverable and clearly scoped to Fusion Framework feature toggling
  - MCP-first guidance degrades cleanly to bundled fallback content
  - offline assets are practical for users without a running server
  - the changeset scope matches only this skill addition
- Risky or security-sensitive parts:
  - no scripts or destructive actions were added
  - main risk is guidance drift if public framework sources change independently of the live MCP index

## Self review checklist

- [x] I scoped this PR to one clear purpose.
- [x] I followed [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I did not include secrets, credentials, or sensitive data.
- [x] I reviewed my own diff for clarity and unintended changes.
