### PR TITLE
fix(skills): harden GitHub API token conservation across issue-authoring and related skills

### DIFF
--- a/.changeset/fix-issue-authoring-session-cache-guidance.md
+++ b/.changeset/fix-issue-authoring-session-cache-guidance.md
@@ -1,0 +1,19 @@
+---
+"fusion-issue-authoring": patch
+"fusion-issue-solving": patch
+"fusion-github-review-resolution": patch
+"fusion-issue-task-planning": patch
+"fusion-dependency-review": patch
+"fusion-discover-skills": patch
+---
+
+Make all GitHub-API-consuming skills more conservative with token usage.
+
+- `fusion-issue-authoring`: concrete session-cache flow for labels and assignee candidates; per-session budget table
+- `fusion-issue-solving`: expanded low-token strategy with session-cache references and budget awareness
+- `fusion-github-review-resolution`: token budget guidance for thread-heavy reviews; cache PR metadata once
+- `fusion-issue-task-planning`: session-cache delegation rules and batch-size warning for large task plans
+- `fusion-dependency-review`: explicit data-reuse rules across parallel advisor fan-out
+- `fusion-discover-skills`: tighter GraphQL budget and call-count cap for discovery sessions
+
+resolves equinor/fusion-core-tasks#797

--- a/skills/.experimental/fusion-dependency-review/SKILL.md
+++ b/skills/.experimental/fusion-dependency-review/SKILL.md
@@ -159,7 +159,8 @@ Always:
 - Present evidence for each assessment (link to changelog, CVE, CI status)
 - List candidate dependency PRs for user selection when repository context exists but the PR target does not
 - Fetch existing PR comments and review threads via GitHub MCP before analysis on a live PR
-- Reuse one shared research packet across advisors instead of rediscovering the same facts in each pass
+- Reuse one shared research packet across advisors instead of rediscovering the same facts in each pass — this includes PR metadata, changed files, CI status, and existing discussion
+- Do not re-fetch PR comments or review threads independently in each advisor; pass the pre-fetched data from the research advisor to all lens advisors
 - Prefer parallel lens analysis when the runtime supports it, then chain synthesis after all lens outputs are ready
 - Post the research checkpoint comment to the PR before any branch mutation on a live PR
 - Post the final verdict comment to the PR before any approval or merge on a live PR

--- a/skills/.experimental/fusion-discover-skills/SKILL.md
+++ b/skills/.experimental/fusion-discover-skills/SKILL.md
@@ -85,7 +85,8 @@ Main workflow:
    - Prefer GitHub MCP repository or search tools when they are available in the current client.
    - Otherwise use read-only shell-based inspection against trusted sources only, such as `npx skills add --list <source>`, local `skills/**/SKILL.md` searches, `gh search code`, or `gh api graphql` against the catalog repository.
    - Use GraphQL only when structured repository data is needed and the higher-level MCP or search tools do not expose it cleanly.
-   - GraphQL read queries cost at least 1 point; keep `first`/`last` small and avoid nested connections to minimize point cost. Do not retry on rate-limit errors; surface the failure and suggest retrying later.
+   - GraphQL read queries cost at least 1 point; keep `first`/`last` small (≤ 30) and avoid nested connections to minimize point cost. Do not retry on rate-limit errors; surface the failure and suggest retrying later.
+   - Budget awareness: a typical skill-discovery session should need at most 2–3 GitHub API calls (one search + one or two content reads). If the first search returns weak results, do one refinement pass and stop — do not loop.
    - Treat GitHub-derived lifecycle guidance as fallback guidance unless Fusion MCP returned an explicit advisory command.
    - Never use remote-script execution patterns or shell pipelines that execute fetched content.
 6. Do one refinement pass when the first result set is weak.

--- a/skills/.experimental/fusion-github-review-resolution/SKILL.md
+++ b/skills/.experimental/fusion-github-review-resolution/SKILL.md
@@ -175,6 +175,14 @@ Review-resolution workflows make multiple GraphQL mutation calls (reply + resolv
 - If a secondary rate-limit error or `retry-after` header is returned, stop processing and respect the indicated wait before retrying.
 - Always prefer a dedicated MCP review-thread tool over raw GraphQL when the client exposes one.
 
+### Token budget guidance
+
+- Fetch the full thread list once and reuse it for all per-thread work; do not re-fetch threads between reply and resolve.
+- Budget estimate: for N unresolved threads expect ~1 list call + N reply mutations + N resolve mutations = 1 + 2N calls. A 10-thread review costs ~21 calls.
+- If the thread count exceeds 15, warn the user about rate-limit risk before starting mutations and offer to batch in smaller groups.
+- Cache PR metadata (title, branch, CI status, changed files) from the first fetch and reuse it for commit messages and replies.
+- Avoid redundant PR-level reads between steps; the data does not change within a single resolution run.
+
 ## Expected output
 
 Return a concise report containing:

--- a/skills/.experimental/fusion-issue-solving/SKILL.md
+++ b/skills/.experimental/fusion-issue-solving/SKILL.md
@@ -78,9 +78,11 @@ Optional inputs:
 4. Apply low-token GitHub strategy
    - Prefer MCP-backed tools over ad hoc `gh api` or GraphQL calls when equivalent tools exist.
    - Avoid duplicate lookups for labels, issue types, and duplicate detection.
-   - Cache per-run context (issue metadata, duplicate matches, issue-type support) and reuse it.
+   - Cache per-run context (issue metadata, duplicate matches, issue-type support, label sets, assignee candidates) and reuse it — do not re-fetch data that was already retrieved in this session.
+   - When delegating to `fusion-issue-authoring` or its subordinate skills, the orchestrator's session-cache rules apply: labels and assignee candidates are fetched once per repository, issue types once per organization.
    - Use GraphQL fallback only when MCP coverage is unavailable and do not loop retries.
    - GraphQL mutations cost 5 secondary-limit points each (vs 1 for queries); batch fields into single calls and pause at least 1 second between mutation calls.
+   - Budget awareness: a typical implementation session (read issue + duplicate check + 1–2 mutations + sub-issue links) should stay under ~20 MCP read calls and ~5 mutations. If the running total approaches 30+ calls, pause optional enrichment and proceed with local work.
    - Respect `retry-after` and `x-ratelimit-reset` headers; do not retry before the indicated wait.
    - If rate limits are hit, stop non-essential operations and continue with local implementation/PR preparation when possible.
 

--- a/skills/.experimental/fusion-issue-task-planning/SKILL.md
+++ b/skills/.experimental/fusion-issue-task-planning/SKILL.md
@@ -103,6 +103,8 @@ Execute in order and state assumptions explicitly.
    - Delegate publish execution to `fusion-issue-authoring` and prefer sub-agent invocation for task issue creation/update/linking.
    - Pass required context to `fusion-issue-authoring`: `owner`, `repo`, parent story reference, ordered task drafts, labels/assignee intent, and dependency ordering.
    - Require `fusion-issue-authoring` to keep MCP-first behavior and apply GraphQL fallback only when MCP write coverage is unavailable.
+   - The orchestrator's session-cache rules apply to all delegated calls: labels, assignee candidates, and issue types are fetched once per session and reused across all task issues in the batch.
+   - Budget awareness: a task-planning publish of N tasks costs ~N issue-write mutations + optional sub-issue link mutations. If N > 5, warn the user about rate-limit risk and offer to publish in batches.
    - Do not call MCP write tools directly from this skill in publish mode.
    - Hard fail publish mode if delegated execution returns unresolved item-level failures.
 

--- a/skills/fusion-issue-authoring/SKILL.md
+++ b/skills/fusion-issue-authoring/SKILL.md
@@ -62,9 +62,9 @@ Collect before publishing:
 - Issue intent/context
 - Issue type (Bug, Feature, User Story, Task)
 - Existing issue number/url when updating
-- Repository label set (or confirmation that labels are intentionally skipped). Reuse cached label results per repository within the same session.
+- Repository label set (or confirmation that labels are intentionally skipped). Cache the full label set per repository for the active session and filter locally instead of validating labels one by one. Prefer host session memory when available; otherwise use a `.tmp/` cache file that is never committed.
 - Parent/related issue links and dependency direction (sub-issue vs blocking)
-- Assignee preference (assign to user, specific person, or leave unassigned)
+- Assignee preference (assign to user, specific person, or leave unassigned). Reuse cached assignee-candidate results for the active session and skip candidate searches when the user already gave `@me` or an exact login.
 
 If required details are missing, ask concise clarifying questions from `references/questions.md`.
 If issue destination is unclear, ask explicitly where the issue should be created/updated before drafting mutation commands.
@@ -108,6 +108,14 @@ Draft in `.tmp/{TYPE}-{CONTEXT}.md` using GitHub Flavored Markdown.
 Before mutation, confirm:
 - labels (only labels that exist in the target repo)
 - assignee intent (`@me`, specific login, or unassigned)
+
+Shared gate cache policy:
+- On the first label lookup for `owner/repo`, fetch the repository label set once and cache it for the active session. Prefer `/memories/session/<owner>-<repo>-labels.json` when the host exposes session memory; otherwise use `.tmp/issue-authoring-labels-<owner>-<repo>.json`.
+- On cache hit, validate requested labels locally. Do not repeat point lookups for each requested label.
+- If the host only exposes point label lookups and no cached label set exists yet, do not loop through labels one by one. Ask whether to skip optional labels or include only user-confirmed labels in the first `mcp_github::issue_write` call and handle a single rejection path.
+- Skip `mcp_github::search_users` when the user already gave `@me` or an exact GitHub login.
+- When assignee lookup is needed, cache candidate results for the active session keyed by owner/repo (or owner) and query. Prefer `/memories/session/<owner>-<repo>-assignee-candidates.json` or `/memories/session/<owner>-assignee-candidates.json`; otherwise use `.tmp/issue-authoring-assignee-candidates-<owner>-<repo>.json`.
+- If rate limits block optional label or assignee enrichment, ask whether to continue without them instead of looping retries.
 
 ### Step 7 — Mutate via MCP (ordered)
 

--- a/skills/fusion-issue-authoring/references/instructions.md
+++ b/skills/fusion-issue-authoring/references/instructions.md
@@ -15,7 +15,8 @@ Goal: create clear GitHub issues fast, with draft-first review and safe mutation
 
 - Fetch required context once and reuse it through the run.
 - Run one focused duplicate check; avoid repeated broad searches.
-- Query labels only when labels are needed for the current mutation.
+- Query labels only when labels are needed for the current mutation, then cache the full repository label set and filter locally.
+- Avoid assignee-candidate lookups when the user already provided `@me` or an exact login; cache ambiguous assignee results for the active session.
 - Cache issue types per organization and skip repeated `list_issue_types` calls on cache hit.
 - Run sub-issue mutations only for relationships that actually changed.
 - If rate limits are hit, stop optional lookups and return a clear retry plan.
@@ -53,7 +54,7 @@ Rate-limit fallback:
 - Do not retry in tight loops; respect `retry-after` and `x-ratelimit-reset` headers.
 - GraphQL mutations cost 5 secondary-limit points each; minimize separate mutation calls.
 - Pause at least 1 second between consecutive GraphQL mutation calls.
-- Preserve local drafts in `.tmp/` and provide a safe retry path for the user.
+- Preserve local drafts in `.tmp/` and any session cache artifacts, then provide a safe retry path for the user.
 
 ## Task mode
 
@@ -75,9 +76,14 @@ Quick check:
 
 ## Labels and assignees
 
-- Query repository labels first; propose only existing labels.
-- If requested labels are missing, ask whether to proceed with available labels.
+- On the first label lookup for `owner/repo`, fetch the repository label set once and write a session cache artifact. Prefer `/memories/session/{owner}-{repo}-labels.json` when the host exposes session memory; otherwise use `.tmp/issue-authoring-labels-{owner}-{repo}.json`.
+- On later label checks, read the cached label set and filter locally; do not validate labels with repeated point lookups.
+- If only point label lookups are available and no cached label set exists, ask whether to continue without optional labels or include only user-confirmed labels in the first `mcp_github::issue_write` call. Do not loop one lookup per label.
+- If requested labels are missing from the cached set, ask whether to proceed with available labels.
 - Ask assignee intent explicitly (`@me`, specific login, or unassigned).
+- If the user gives `@me` or an exact GitHub login, do not run `mcp_github::search_users`.
+- When assignee search is needed, cache the result set for the active session keyed by owner/repo (or owner) and query. Prefer `/memories/session/{owner}-{repo}-assignee-candidates.json` or `/memories/session/{owner}-assignee-candidates.json`; otherwise use `.tmp/issue-authoring-assignee-candidates-{owner}-{repo}.json`.
+- If the host exposes repository contributors or organization members, hydrate that cache once and reuse it; otherwise reuse the first `mcp_github::search_users` result for the same query.
 
 ## MCP reference
 

--- a/skills/fusion-issue-authoring/references/mcp-server.md
+++ b/skills/fusion-issue-authoring/references/mcp-server.md
@@ -17,6 +17,8 @@ Use this file for GitHub MCP-specific tools and payload examples.
 
 Common expensive paths in issue workflows:
 
+- repeated label lookups for the same repository,
+- repeated assignee-candidate searches for the same repository/org and query,
 - repeated `list_issue_types` calls per issue,
 - repeated duplicate searches with broad queries,
 - unnecessary second-pass issue updates for labels/assignees,
@@ -24,6 +26,8 @@ Common expensive paths in issue workflows:
 
 Mitigation policy:
 
+- cache repository labels per `owner/repo` for the active session,
+- cache assignee-candidate results per `owner/repo` (or owner) and query for the active session,
 - cache issue types per owner for the active session,
 - run one focused duplicate search unless scope materially changes,
 - send full known issue payload in the first `issue_write` call,
@@ -80,6 +84,35 @@ There is no dedicated Issues MCP tool in this set for setting blocking/blocked l
 - Use `mcp_github::list_issue_types` to get valid type values for the organization.
 - Only send `type` when the repository has issue types configured.
 - If issue types are unsupported, omit `type`.
+
+## Label lookup caching (recommended)
+
+Do **not** validate requested labels with one point lookup per label.
+
+Use this strategy:
+
+1. On the first label request for `owner/repo`, do one repository-wide label fetch or equivalent bulk read and cache the result for the active session.
+2. Prefer a host session-memory artifact when available:
+  - `/memories/session/<owner>-<repo>-labels.json`
+  - fallback: `.tmp/issue-authoring-labels-<owner>-<repo>.json` (never committed)
+3. On cache hit, filter requested labels locally and send only the surviving set in the first `mcp_github::issue_write` call.
+4. If the host only exposes point label lookups and no cached label set exists yet, do not loop through labels. Ask whether to skip optional labels or include only user-confirmed labels in the first mutation and accept a single rejection path.
+5. Refresh the cache only when the repository changes or the user explicitly asks for a reload.
+
+## Assignee candidate caching (recommended)
+
+Do **not** repeat the same assignee-candidate lookup for every issue in a session.
+
+Use this strategy:
+
+1. If the user says `@me` or gives an exact GitHub login, skip `mcp_github::search_users` entirely.
+2. When lookup is needed, cache candidate results keyed by `owner/repo + query` (or `owner + query` if repository scoping is unavailable).
+3. Prefer a host session-memory artifact when available:
+  - `/memories/session/<owner>-<repo>-assignee-candidates.json`
+  - `/memories/session/<owner>-assignee-candidates.json`
+  - fallback: `.tmp/issue-authoring-assignee-candidates-<owner>-<repo>.json` (never committed)
+4. If the host exposes repository contributors or organization members, hydrate that cache once per session and reuse it. Otherwise, reuse the first `mcp_github::search_users` result for the same query.
+5. If rate limits block candidate enrichment, ask whether to continue unassigned or with `@me` instead of retrying lookup loops.
 
 ## Issue type lookup caching (recommended)
 
@@ -167,7 +200,7 @@ Use either `after_id` or `before_id` for reprioritization.
 
 ## Minimal task-batch order
 
-1. `mcp_github::issue_write` create/update with full known fields (`title`, `body`, `labels`, `assignees`, optional `type`)
+1. `mcp_github::issue_write` create/update with full known fields (`title`, `body`, `labels`, `assignees`, optional `type`) using cache-backed label/assignee data when available
 2. Optional single follow-up `mcp_github::issue_write` only for fields that were unavailable in step 1
 3. `mcp_github::sub_issue_write` add/reprioritize children in execution order only when linkage changed
 4. Optional: `mcp_github::add_issue_comment` to record blocker context when requested
@@ -187,8 +220,24 @@ GitHub GraphQL limits (summary from https://docs.github.com/en/graphql/overview/
 Behavior when limits are approached or hit:
 
 - Check `x-ratelimit-remaining` and `retry-after` headers; respect the reset window.
-- Stop optional enrichments and avoid automatic retry loops.
+- Stop optional label/assignee enrichments and avoid automatic retry loops.
 - Pause at least 1 second between consecutive mutation calls.
 - Preserve draft state and return a clear retry sequence to the user.
 - Prefer MCP calls over ad hoc GraphQL retries when equivalent MCP tools are available.
 - Never retry a request that returned a secondary rate-limit error without waiting for the `retry-after` period.
+
+### Per-session budget estimate
+
+A typical multi-issue authoring session with cache-first behavior:
+
+| Activity | Calls (with caching) | Calls (without caching) |
+|---|---|---|
+| Label set fetch per repo | 1 | N × L (N issues × L labels each) |
+| Issue-type lookup per org | 1 | N |
+| Duplicate search per issue | N | N |
+| Assignee lookup per session | 0–1 | N |
+| Issue create/update | N | N |
+| Sub-issue link | 0–N | 0–N |
+| **Total for 3 issues, 3 labels each** | **~10** | **~25+** |
+
+Stay under ~30 MCP calls per session for a typical 3-issue run. If the running total approaches this threshold, stop optional enrichment (extra label checks, assignee searches, duplicate re-scans) and proceed with the data already cached.


### PR DESCRIPTION
## Why

All GitHub-API-consuming skills lacked concrete token conservation guidance. In multi-issue or multi-thread sessions the cumulative API calls easily exhausted GitHub rate limits, leaving labels unapplied, assignees unresolved, and mutations failing silently.

## Current behavior

- `fusion-issue-authoring` mentions caching intent but provides no concrete cache-first flow for labels or assignee candidates.
- `fusion-issue-solving` caches "issue metadata" but does not reference the orchestrator's session-cache rules or budget awareness.
- `fusion-github-review-resolution` documents GraphQL cost per mutation but does not budget for thread-heavy reviews or cache PR metadata across steps.
- `fusion-issue-task-planning` delegates to `fusion-issue-authoring` but does not enforce session-cache reuse across batch publishes.
- `fusion-dependency-review` re-fetches PR context independently in each advisor.
- `fusion-discover-skills` uses unbounded `first`/`last` in GraphQL and has no call-count cap.

## New behavior

- **fusion-issue-authoring**: concrete label and assignee session-cache flow with file-path conventions; per-session budget table showing cached vs uncached call counts.
- **fusion-issue-solving**: expanded low-token strategy referencing the orchestrator's session-cache rules; budget-awareness threshold (~30 calls).
- **fusion-github-review-resolution**: token budget guidance with formula (1 + 2N calls for N threads); warning at 15+ threads; PR metadata caching.
- **fusion-issue-task-planning**: explicit session-cache delegation rule and batch-size warning for >5 tasks.
- **fusion-dependency-review**: data-reuse rules requiring research advisor output to be shared across all lens advisors.
- **fusion-discover-skills**: `first`/`last` capped at ≤30; call-count cap of 2–3 API calls per discovery session.

## References

- Issue(s): resolves equinor/fusion-core-tasks#797
- Related PR(s):
- Docs / specs: skills/fusion-issue-authoring/SKILL.md, skills/fusion-issue-authoring/references/instructions.md, skills/fusion-issue-authoring/references/mcp-server.md, skills/.experimental/fusion-issue-solving/SKILL.md, skills/.experimental/fusion-github-review-resolution/SKILL.md, skills/.experimental/fusion-issue-task-planning/SKILL.md, skills/.experimental/fusion-dependency-review/SKILL.md, skills/.experimental/fusion-discover-skills/SKILL.md

## Reviewer focus

- Start here (files/areas): skills/fusion-issue-authoring/references/mcp-server.md (budget table + label/assignee cache sections)
- Verify these behavior changes: label validation documented as bulk-fetch + session cache; per-session budget estimates across all skills; review-resolution thread batching warning
- Risky or security-sensitive parts: documentation-only changes affecting how agents use GitHub MCP lookups — no code execution changes

## Self review checklist

- [x] I scoped this PR to one clear purpose.
- [x] I followed [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I did not include secrets, credentials, or sensitive data.
- [x] I reviewed my own diff for clarity and unintended changes.