### PR TITLE
Update C# conventions for clarity and consistency

### DIFF
--- a/.changeset/csharp-conventions-clarity.md
+++ b/.changeset/csharp-conventions-clarity.md
@@ -1,0 +1,9 @@
+---
+"fusion-code-conventions": patch
+---
+
+Improve C# conventions for clarity and consistency
+
+- Separate Controllers/ and Endpoints/ into distinct lines in the project layout to avoid ambiguity
+- Clarify Startup.cs guidance to distinguish the older Startup class pattern from the .NET 6+ minimal hosting model
+- Broaden error-handling guidance to cover both minimal API and MVC ProblemDetails helpers across supported target frameworks

--- a/skills/.system/fusion-code-conventions/references/csharp.conventions.md
+++ b/skills/.system/fusion-code-conventions/references/csharp.conventions.md
@@ -9,7 +9,7 @@ Naming, null safety, async/await, and code style conventions for C# projects.
 ASP.NET Core services commonly follow a layered internal layout similar to:
 
 ```
-Controllers/ or Endpoints/ ← API controllers (MVC) or endpoint definitions (minimal APIs)
+Controllers/               ← API controllers (MVC)
 Domain/
   Commands/                ← MediatR IRequest command + nested Handler class
   Query/                   ← MediatR IRequest query + nested Handler class
@@ -25,8 +25,8 @@ Integrations/              ← External service client adapters
 Program.cs                 ← Entry point (and DI registration for minimal APIs)
 ```
 
-Add a `Startup.cs` if using the traditional `IStartup` / `WebApplicationBuilder` separation pattern.
-For minimal APIs, endpoint definitions may live in an `Endpoints/` folder or be organized by feature.
+Use a `Startup.cs` (with `ConfigureServices` / `Configure`) only when following the older ASP.NET Core Startup class pattern or a custom startup abstraction.
+For minimal APIs using the .NET 6+ hosting model, keep configuration in `Program.cs`; endpoint definitions may live in an `Endpoints/` folder or be organized by feature.
 
 Common reusable packages and shared libraries live in a separate `common/` or `shared/` directory.
 Integration tests live in a sibling `test/` directory, mirroring the production project name.
@@ -106,7 +106,7 @@ Integration tests live in a sibling `test/` directory, mirroring the production 
 
 - Domain errors are typed exceptions that extend `Exception` directly (`RoleExistsError : Exception`).
 - Constructor sets a formatted message; the class exposes domain-specific read-only properties.
-- Return RFC 7807 Problem Details responses for errors — use `TypedResults.Problem(...)` in minimal APIs or the `ProblemDetails` middleware in MVC.
+- Return RFC 7807 Problem Details responses for errors — for minimal APIs use the built-in ProblemDetails helpers (for example `Results.Problem(...)` / `TypedResults.Problem(...)`, depending on target framework); for MVC use `ControllerBase.Problem(...)` and/or the built-in exception handler middleware that produces ProblemDetails.
 - Catch the specific domain exception; let middleware handle unexpected exceptions.
 
 ## Code style (enforced via `.editorconfig`)


### PR DESCRIPTION
## Why

The C# conventions reference had ambiguous wording in the project structure section and error-handling guidance that was too narrowly scoped to specific framework versions. Copilot code review flagged three areas needing clarification.

## Current behavior

- The project layout listed `Controllers/ or Endpoints/` as a single line, making it look like a literal directory name.
- The `Startup.cs` guidance mixed unrelated hosting models (`IStartup` with `WebApplicationBuilder`).
- Error-handling guidance only mentioned `TypedResults.Problem(...)`, which is version-specific and didn't cover MVC helpers.

## New behavior

- `Controllers/` is listed as its own line in the project layout code block; `Endpoints/` is covered in the prose below the layout.
- `Startup.cs` guidance now clearly distinguishes the older Startup class pattern from the .NET 6+ minimal hosting model.
- Error-handling guidance covers both minimal API and MVC ProblemDetails helpers across supported target frameworks.

## References

- Related PR(s): equinor/fusion-skills#120 (Copilot review comments)

## Reviewer focus

- Start here (files/areas): `skills/.system/fusion-code-conventions/references/csharp.conventions.md`
- Verify these behavior changes: project layout code block (line 12), Startup.cs paragraph (lines 28-29), error handling bullet (line 109)
- Risky or security-sensitive parts: none — documentation-only changes

## Self review checklist

- [x] I scoped this PR to one clear purpose.
- [x] I followed [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I did not include secrets, credentials, or sensitive data.
- [x] I reviewed my own diff for clarity and unintended changes.
