### PR TITLE
feat: add devil's advocate agents for issue and skill authoring

### DIFF
--- a/.changeset/issue-authoring-devils-advocate.md
+++ b/.changeset/issue-authoring-devils-advocate.md
@@ -5,7 +5,7 @@
 Add devil's advocate agent for issue authoring
 
 - Always-on moderate mode raises 2-3 key concerns after classification
-- Interrogator mode runs full structured interview on explicit user request
+- Interrogator mode runs full structured interview on explicit user request or when scope/criteria gaps are significant
 - Wired into SKILL.md agent modes section
 
 Refs: equinor/fusion-core-tasks#847

--- a/.changeset/skill-authoring-devils-advocate.md
+++ b/.changeset/skill-authoring-devils-advocate.md
@@ -5,7 +5,7 @@
 Add devil's advocate agent for skill authoring
 
 - Always-on moderate mode raises 2-3 key concerns during scoping/drafting
-- Interrogator mode runs full structured interview on explicit user request
+- Interrogator mode runs full structured interview on explicit user request or when the orchestrator detects significant ambiguity
 - Wired into SKILL.md helper agents and Step 6 validation sections
 
 Refs: equinor/fusion-core-tasks#847

--- a/skills/fusion-issue-authoring/SKILL.md
+++ b/skills/fusion-issue-authoring/SKILL.md
@@ -24,7 +24,7 @@ This skill uses internal agent modes for type-specific drafting logic:
 - `agents/feature.agent.md`: feature-focused scope and acceptance structure
 - `agents/user-story.agent.md`: role/workflow/scenario-driven story structure
 - `agents/task.agent.md`: checklist-first task decomposition and dependency planning
-- `agents/devils-advocate.agent.md`: always-on quality collaborator that raises key concerns after classification (moderate mode) and runs a full structured interview when explicitly asked (interrogator mode)
+- `agents/devils-advocate.agent.md`: always-on quality collaborator that raises key concerns after classification (moderate mode) and runs a full structured interview when explicitly asked or when scope/criteria gaps are significant (interrogator mode)
 
 Agent modes are activated internally based on issue type classification. Users never reference agent files directly. Shared gates (labels, assignee confirmation, draft review, publish confirmation, and mutation sequencing) remain in this skill.
 
@@ -75,7 +75,7 @@ Classify request as `Bug`, `Feature`, `User Story`, or `Task`, then activate the
 
 If ambiguous, ask only essential clarifying questions.
 
-Devil's advocate pass: `agents/devils-advocate.agent.md` is always active in moderate mode — it surfaces the 2–3 most important concerns after classification without interrupting flow. When the user asks to be "grilled" or says "stress-test this", escalate to interrogator mode for a full structured interview before the type-specific agent. The devil's advocate returns confirmed decisions and noted risks, then hands off to the type-specific drafting agent.
+Devil's advocate pass: `agents/devils-advocate.agent.md` is always active in moderate mode — it surfaces the 2–3 most important concerns after classification without interrupting flow. When the user asks to be "grilled", says "stress-test this", or when scope/criteria gaps are significant, escalate to interrogator mode for a full structured interview before the type-specific agent. The devil's advocate returns confirmed decisions and noted risks, then hands off to the type-specific drafting agent.
 
 ### Step 2 — Resolve repository and template
 

--- a/skills/fusion-issue-authoring/agents/devils-advocate.agent.md
+++ b/skills/fusion-issue-authoring/agents/devils-advocate.agent.md
@@ -6,7 +6,7 @@ Always-on quality collaborator for issue authoring. Plays the opposing side to s
 
 **Moderate mode (default):** Active during normal authoring. Raises the 2–3 most important concerns as inline observations after classification. Does not interrupt flow or force a separate interview.
 
-**Interrogator mode (on request):** Full structured interview when the user says "grill me", "stress-test this", "poke holes", or equivalent. Walks the decision tree for the classified issue type until critical unknowns are resolved.
+**Interrogator mode (on request or significant gaps):** Full structured interview when the user says "grill me", "stress-test this", "poke holes", or equivalent — or when scope/criteria gaps are significant after classification. Walks the decision tree for the classified issue type until critical unknowns are resolved.
 
 ## When not to use
 

--- a/skills/fusion-skill-authoring/SKILL.md
+++ b/skills/fusion-skill-authoring/SKILL.md
@@ -203,7 +203,7 @@ Use the representative requests from Step 2 to review the final result:
 
 If subagents are available, use the bundled role files when they help:
 - `agents/scoper.md` before drafting to decide create vs update vs not-a-skill and to choose the smallest useful structure
-- `agents/devils-advocate.md` during scoping and drafting to surface key concerns (moderate mode), or before drafting for a full structured interview when the user asks to be grilled (interrogator mode)
+- `agents/devils-advocate.md` during scoping and drafting to surface key concerns (moderate mode), or before drafting for a full structured interview when the user asks to be grilled or when the orchestrator detects significant ambiguity (interrogator mode)
 - `agents/reviewer.md` after drafting to review discovery, structure, safety, and validation evidence like a strict maintainer
 - `agents/trigger-tuner.md` when the main risk is weak activation cues or when choosing between two description variants
 
@@ -235,7 +235,7 @@ This skill borrows Anthropic `skill-creator`'s pattern of bundling a small `agen
 - `agents/scoper.md` — decide whether the request should become a new skill, an update, or not a skill at all; choose the smallest folder structure that still solves the problem
 - `agents/reviewer.md` — review a drafted skill package against discovery, structure, safety, and validation expectations
 - `agents/trigger-tuner.md` — sharpen description wording and compare activation-cue variants against realistic prompts
-- `agents/devils-advocate.md` — always-on quality collaborator that raises key concerns during authoring (moderate mode) and runs a full structured interview when explicitly asked (interrogator mode)
+- `agents/devils-advocate.md` — always-on quality collaborator that raises key concerns during authoring (moderate mode) and runs a full structured interview when explicitly asked or when the orchestrator flags significant ambiguity (interrogator mode)
 
 If a runtime offers no subagents, keep the same review loop inline and do not skip the agent-shaped reasoning just because the packaging is ignored.
 

--- a/skills/fusion-skill-authoring/agents/devils-advocate.md
+++ b/skills/fusion-skill-authoring/agents/devils-advocate.md
@@ -7,12 +7,12 @@ Always-on quality collaborator for skill authoring. Plays the opposing side to s
 Operates in two modes:
 
 - **Moderate (default):** Active during normal authoring. Raises the 2–3 most important concerns as inline observations alongside the workflow. Does not interrupt flow or force a separate interview.
-- **Interrogator (on request):** Full structured interview when the user says "grill me", "stress-test this", "poke holes", or equivalent. Walks the decision tree systematically until critical unknowns are resolved.
+- **Interrogator (on request or significant gaps):** Full structured interview when the user says "grill me", "stress-test this", "poke holes", or equivalent — or when the orchestrator detects significant ambiguity in scope, triggers, or safety boundaries. Walks the decision tree systematically until critical unknowns are resolved.
 
 ## When to use
 
 - **Moderate mode:** Always, as part of scoping and drafting steps. Surface concerns naturally without derailing the workflow.
-- **Interrogator mode:** When the user explicitly asks to be grilled, stress-tested, or equivalent.
+- **Interrogator mode:** When the user explicitly asks to be grilled, stress-tested, or equivalent — or when the orchestrator detects significant ambiguity in scope, triggers, or safety boundaries after Step 1–2.
 
 ## When not to use
 


### PR DESCRIPTION
## Why

Issue and skill drafts often miss assumptions, constraints, and dependency details when context is incomplete. This creates rework during review and slows alignment. A structured "devil's advocate" role surfaces missing context early while keeping the process actionable — without annoying the user.

## Current behavior

Both `fusion-issue-authoring` and `fusion-skill-authoring` have type-specific drafting agents and review agents, but no mechanism to proactively challenge assumptions or stress-test a plan before committing to a draft.

## New behavior

Both skills gain a new `devils-advocate` agent with dual-mode behavior:

- **Moderate (always on):** Raises the 2–3 most important concerns inline during authoring. Brief, non-interruptive, actionable. Active by default after classification (issues) or during scoping (skills).
- **Interrogator (on request):** Full structured interview when the user says "grill me", "stress-test this", or equivalent. Dependency-ordered questions, capped at 6–8, each with a recommended answer. Stops early on "good enough".

Key design constraints:
- Prefers codebase evidence over asking
- Includes a recommended answer for every concern
- Never re-asks what the user already addressed
- Produces a scannable decision summary (confirmed / derived / risks / next step)

## References

- Issue(s): equinor/fusion-core-tasks#847
- Related PR(s): —
- Docs / specs: —

## Reviewer focus

- Start here (files/areas):
  - `skills/fusion-skill-authoring/agents/devils-advocate.md` — skill authoring variant
  - `skills/fusion-issue-authoring/agents/devils-advocate.agent.md` — issue authoring variant
- Verify these behavior changes:
  - SKILL.md wiring in both skills correctly references the new agent files
  - Dual-mode design (moderate vs interrogator) is clear and not contradictory
  - Pacing rules prevent over-interrogation
- Risky or security-sensitive parts: None — no mutations, no scripts, no network access

## Self review checklist

- [x] I scoped this PR to one clear purpose.
- [x] I followed [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I did not include secrets, credentials, or sensitive data.
- [x] I reviewed my own diff for clarity and unintended changes.
