### PR TITLE
feat(skills): add fusion-developer-portal skill for portal shell development

### DIFF
--- a/.changeset/fusion-developer-portal-initial.md
+++ b/.changeset/fusion-developer-portal-initial.md
@@ -10,4 +10,4 @@ Add fusion-developer-portal skill for Fusion portal shell development
 - Includes portal routing, chrome (header, context selector), analytics, and telemetry
 - Reference file with full portal architecture patterns from framework cookbooks
 
-Resolves equinor/fusion-core-tasks#752
+resolves equinor/fusion-core-tasks#752

--- a/skills/fusion-developer-portal/SKILL.md
+++ b/skills/fusion-developer-portal/SKILL.md
@@ -195,12 +195,14 @@ For telemetry (OpenTelemetry / Application Insights), see [references/portal-arc
 # Build the portal template
 ffc portal build
 
-# Upload to the Fusion portal service
-ffc portal upload --portal-id <id> --token <pat>
+# Upload to the Fusion portal service (authenticate via `az login` or FUSION_TOKEN env var)
+ffc portal upload --portal-id <id>
 
 # Tag a specific version
 ffc portal tag --portal-id <id> --tag latest --version <version>
 ```
+
+> **Never paste tokens directly into commands.** Use `az login` for interactive auth or set the `FUSION_TOKEN` environment variable for CI pipelines.
 
 ### Step 8 — Validate
 

--- a/skills/fusion-developer-portal/references/portal-architecture.md
+++ b/skills/fusion-developer-portal/references/portal-architecture.md
@@ -145,18 +145,19 @@ export const AppLoader = (props: { readonly appKey: string }) => {
   }, [appKey, fusion]);
 
   useEffect(() => {
+    if (!currentApp) return;
+
     setLoading(true);
     setError(undefined);
     const subscription = new Subscription();
 
     subscription.add(
       currentApp
-        ?.initialize()
+        .initialize()
         .pipe(last())
         .subscribe({
           next: ({ manifest, script, config }) => {
-            const [basename] =
-              window.location.pathname.match(/\/?apps\/[a-z|-]+(\/)?/g) ?? [''];
+            const basename = `/apps/${appKey}`;
             const el = document.createElement('div');
             if (!ref.current) throw Error('Missing application mounting point');
             ref.current.appendChild(el);
@@ -166,7 +167,10 @@ export const AppLoader = (props: { readonly appKey: string }) => {
             subscription.add(() => el.remove());
           },
           complete: () => setLoading(false),
-          error: (err) => setError(err),
+          error: (err) => {
+            setLoading(false);
+            setError(err);
+          },
         }),
     );
 


### PR DESCRIPTION
## Why

Fusion portal development (building custom portal shells that host Fusion apps) has no dedicated skill guidance. Developers building portals need help with scaffolding, portal-level module configuration (`FrameworkConfigurator` vs `AppModuleInitiator`), app loading, routing, analytics, and deployment — concerns that are distinct from app-level feature development covered by `fusion-app-react-dev`.

This also absorbs the app-loader patterns from equinor/fusion-core-tasks#752 (Apploader component, useApploader hook, custom AppLoader with RxJS, app initialization lifecycle).

## Current behavior

No skill exists for portal development. Developers building custom Fusion portals must piece together guidance from framework cookbooks, CLI docs, and the dev-portal package README manually.

## New behavior

- New `fusion-developer-portal` skill (236 lines) guides portal shell development end-to-end
- Covers: scaffolding (`ffc portal dev/build/upload`), `portal.manifest.ts`, portal-level module config, app loading (Apploader + custom AppLoader), routing, chrome (header, context selector), analytics/telemetry, deployment
- Reference file (`references/portal-architecture.md`) with annotated patterns from `portal-analytics` and `portal` cookbooks
- MCP-suggested (not required) for staying current with framework changes
- Single-scope changeset included

## References

- Issue(s): Resolves equinor/fusion-core-tasks#752
- Related PR(s): —
- Docs / specs: [Portal CLI docs](https://github.com/equinor/fusion-framework/blob/main/packages/cli/docs/portal.md), [Dev Portal README](https://github.com/equinor/fusion-framework/blob/main/packages/dev-portal/README.md), [Portal Analytics Cookbook](https://github.com/equinor/fusion-framework/tree/main/cookbooks/portal-analytics)

## Reviewer focus

- Start here (files/areas): `skills/fusion-developer-portal/SKILL.md` — main skill file (236 lines)
- Verify these behavior changes: Skill appears in `npx -y skills add . --list`, activates for portal-related prompts
- Risky or security-sensitive parts: None — read-only guidance skill, no scripts or mutations

## Self review checklist

- [x] I scoped this PR to one clear purpose.
- [x] I followed [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I did not include secrets, credentials, or sensitive data.
- [x] I reviewed my own diff for clarity and unintended changes.

## Validation evidence

```
$ wc -l skills/fusion-developer-portal/SKILL.md
236

$ npx -y skills add . --list | grep developer-portal
fusion-developer-portal

$ bun run validate:skills
Skill count check passed.

$ bun run validate:ownership
Ownership validation: 26/26 skills passed.
✓ All skills have valid ownership metadata.
```
