### PR TITLE
feat(fusion-tsdoc-readme): add reusable TSDoc and README documentation skill

### DIFF
--- a/.changeset/add-fusion-tsdoc-readme-skill.md
+++ b/.changeset/add-fusion-tsdoc-readme-skill.md
@@ -1,0 +1,12 @@
+---
+"fusion-tsdoc-readme": minor
+---
+
+Add reusable skill for systematic TSDoc and README documentation passes
+
+- Orchestrator SKILL.md with TSDoc pass, README pass, and review council workflow
+- Three agents: tsdoc (export scanning and TSDoc improvement), readme (structure assessment and rewrite), reviewer (four-dimension quality review)
+- References for README structure guide and multi-package orchestration strategy
+- README template asset for consistent package documentation
+
+Resolves equinor/fusion-core-tasks#702

--- a/skills/fusion-tsdoc-readme/SKILL.md
+++ b/skills/fusion-tsdoc-readme/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: fusion-tsdoc-readme
+description: 'Systematically improves TSDoc and README documentation across packages in a monorepo. USE FOR: running documentation passes on one or more packages, adding TSDoc to all public exports, rewriting READMEs to a consistent retrieval-friendly structure, and orchestrating multi-package doc runs with parallelization guidance. DO NOT USE FOR: single TSDoc fixes (use fusion-code-conventions), API reference site generation, product-code changes, or runtime debugging.'
+license: MIT
+metadata:
+  version: "0.0.0"
+  status: experimental
+  owner: "@equinor/fusion-core"
+  role: orchestrator
+  skills:
+    - fusion-code-conventions
+  tags:
+    - tsdoc
+    - readme
+    - documentation
+    - monorepo
+    - code-review
+    - orchestration
+---
+
+# TSDoc & README Documentation
+
+## When to use
+
+Use this skill when you need to systematically improve documentation across one or more packages — adding TSDoc to public exports, rewriting READMEs to a consistent structure, or orchestrating a multi-package documentation pass.
+
+Typical triggers:
+- "Document all public exports in this package"
+- "Run a TSDoc pass on packages X, Y, Z"
+- "Rewrite the README for this package"
+- "Make the documentation consistent across these packages"
+- "Add TSDoc to everything that's missing it"
+- "Prepare documentation for all packages in this monorepo"
+
+Implicit triggers:
+- A monorepo has inconsistent or missing documentation across packages
+- A documentation sprint is planned to cover multiple packages
+- Package READMEs are stale, incomplete, or structurally inconsistent
+
+## When not to use
+
+Do not use this skill for:
+- Fixing TSDoc on a single function or small snippet (use `fusion-code-conventions` directly)
+- Generating API reference websites or static doc sites
+- Product-code changes, refactors, or new features
+- Runtime debugging or performance profiling
+- Writing documentation for non-code artifacts (use Markdown conventions from `fusion-code-conventions`)
+
+## Required inputs
+
+### Mandatory
+
+- **Target packages**: one or more package paths to document
+- **Repository root**: the monorepo root for discovering project conventions
+
+### Conditional
+
+- **Tracking issue number**: when package-level sub-issues should be assigned, updated, and closed on completion
+- **README template path**: when the repository has a custom README structure (otherwise use `assets/readme-template.md`)
+- **Commit format**: when the repository uses a non-standard commit convention (default: `docs(<package>): <summary>`)
+
+## Instructions
+
+### Step 1 — Discover project conventions
+
+Before writing any documentation, inspect the target repository:
+
+1. Read `package.json` (root and target package) for package name, description, and scripts.
+2. Read `tsconfig.json` for TypeScript settings and path aliases.
+3. Check for code-generation or documentation instruction files (e.g. `.github/instructions/code-generation.instructions.md`, `.github/instructions/documentation.instructions.md`).
+4. Check for `CONTRIBUTING.md` or a `contribute/` directory for project-specific standards.
+5. Check for linter/formatter config (`biome.json`, `.eslintrc`, prettier config).
+
+**Project conventions override skill defaults.** If the repository documents its own TSDoc rules, README structure, or commit format, follow those.
+
+When no project-specific standards exist, use:
+- `fusion-code-conventions` TSDoc rules as the TSDoc baseline
+- `assets/readme-template.md` as the README structure baseline
+
+### Step 2 — Plan the documentation pass
+
+For each target package:
+
+1. Scan all source files and identify every public export (functions, classes, interfaces, types, enums, constants, React components, hooks).
+2. Classify each export's current documentation state:
+   - **Missing**: no TSDoc at all
+   - **Incomplete**: TSDoc present but missing required tags (`@param`, `@returns`, `@template`, `@throws`, `@example`)
+   - **Weak**: TSDoc present but restates the function name instead of explaining intent
+3. Read the current README and assess against `references/readme-structure.md`.
+4. Produce a package-level work plan listing files to touch and estimated scope.
+
+For multi-package runs, see `references/orchestration.md` for batching and parallelization strategy.
+
+### Step 3 — TSDoc pass
+
+For each public export, add or improve TSDoc following these rules:
+
+- **Summary line**: explain *intent and why*, not *what the name already says*
+- **`@param`**: every parameter — describe purpose, constraints, and edge case behavior
+- **`@returns`**: every non-void function — describe the shape and semantics of the return value
+- **`@template`**: every generic type parameter — explain the constraint and typical usage
+- **`@throws`**: meaningful error paths — document the error type and trigger condition
+- **`@example`**: user-facing and non-trivial public APIs — show realistic usage
+- **`@deprecated`**: when superseded — include the replacement
+
+Delegate specific convention questions to `fusion-code-conventions` when they arise. That skill owns the authoritative TSDoc tag rules; this skill owns the systematic pass workflow.
+
+### Step 4 — README pass
+
+Rewrite or restructure each package README following `references/readme-structure.md`:
+
+1. Verify the README has all required sections in the correct order.
+2. Ensure the description accurately reflects what the package does today.
+3. Add or update installation, usage, and configuration sections with working examples.
+4. Add or update the API reference section — link to or summarize key public exports.
+5. Remove stale content that no longer matches the package's current API surface.
+
+Use `assets/readme-template.md` as the structural baseline unless the project has its own template.
+
+### Step 5 — Review council
+
+Before finalizing changes, verify quality across four dimensions:
+
+| Dimension | Check |
+|---|---|
+| **Intent extraction** | Does the TSDoc explain *why* the code exists, not just parrot the name? |
+| **Code comprehension** | Are complex algorithms, state machines, or side effects explained? |
+| **User-facing quality** | Would a developer discovering this package for the first time understand it from the README? |
+| **Retrieval fitness** | Will the documentation produce good hits in RAG / semantic search / code search? |
+
+Use `agents/reviewer.agent.md` for a structured review pass, or apply the same criteria inline when subagents are unavailable.
+
+### Step 6 — Commit and close
+
+1. Stage and commit changes per package using the repository's commit format (default: `docs(<package>): improve TSDoc and README`).
+2. Push the branch.
+3. If a tracking issue was provided, close it with a summary of what was documented.
+
+### Multi-package orchestration
+
+When documenting more than one package, follow `references/orchestration.md` for:
+- Batch sizing based on package complexity
+- Context isolation between packages to avoid cross-contamination
+- Progress tracking and checkpoint strategy
+- When to split work across sub-agents vs. inline sequentially
+
+## Agent modes
+
+| Agent | Activated for |
+|---|---|
+| `agents/tsdoc.agent.md` | TSDoc analysis, gap identification, and improvement for a single package |
+| `agents/readme.agent.md` | README structure assessment and rewrite for a single package |
+| `agents/reviewer.agent.md` | Review council — quality, intent, comprehension, and retrieval fitness checks |
+
+If the runtime does not support skill-local agents, apply the same review criteria inline.
+
+## Expected output
+
+- Modified source files with complete TSDoc on all public exports
+- Rewritten README following the consistent structure
+- Commit(s) following the repository's conventional commit format
+- A summary of what was documented: packages touched, exports documented, README sections added/updated
+- Review council findings: any remaining quality concerns or follow-up items
+
+## Safety & constraints
+
+Never:
+- Modify source code logic — documentation changes only
+- Remove or weaken existing accurate documentation
+- Invent API behavior that is not present in the source code
+- Request or expose secrets or credentials
+- Push to protected branches without explicit confirmation
+- Skip the review step for multi-package runs
+
+Always:
+- Read the source code before writing TSDoc — accuracy over coverage speed
+- Preserve existing accurate documentation and only improve gaps
+- Follow project-specific conventions when they override skill defaults
+- Commit per-package to keep history clean and reviewable
+- Delegate convention questions to `fusion-code-conventions`

--- a/skills/fusion-tsdoc-readme/agents/readme.agent.md
+++ b/skills/fusion-tsdoc-readme/agents/readme.agent.md
@@ -1,0 +1,62 @@
+# README Agent
+
+## When to use
+
+Activated by the orchestrator to assess and rewrite a single package's README to a consistent, retrieval-friendly structure.
+
+## When not to use
+
+- Do not use for TSDoc changes (use `tsdoc.agent.md`)
+- Do not use for quality review (use `reviewer.agent.md`)
+- Do not use for general Markdown formatting (use `fusion-code-conventions`)
+
+## Required inputs
+
+- Package root path
+- Current package README (may be absent)
+- Project conventions discovered by the orchestrator (README template, structure rules)
+- Package metadata: name, description, public API summary (from TSDoc pass or package.json)
+
+## Instructions
+
+1. **Read the current README.** If the package has no README, note it as absent. If one exists, read it fully and assess against `references/readme-structure.md`.
+
+2. **Gather package context.** Read:
+   - `package.json` for name, description, keywords, dependencies, and entry points
+   - The public API surface (ideally from the TSDoc agent's output, otherwise scan exports)
+   - Any existing usage examples in tests or documentation
+
+3. **Assess structure gaps.** Compare the current README against the required sections in `references/readme-structure.md`:
+   - Package name and badges
+   - Description
+   - Features
+   - Installation
+   - Usage
+   - API reference
+   - Configuration (conditional)
+   - Related packages (conditional)
+
+4. **Rewrite the README.** Apply the project's README template (or `assets/readme-template.md` as fallback):
+   - Write the description from scratch based on the package's actual API surface — do not copy stale descriptions
+   - Write feature bullets from the public API and package behavior, not from marketing claims
+   - Write installation using the monorepo's package manager
+   - Write usage examples that actually work — verify imports and API calls match the current source
+   - Summarize the API with an export table linking to or describing key public symbols
+   - Remove stale sections that no longer match the package
+
+5. **Report findings.** Return to the orchestrator:
+   - Sections added, updated, or removed
+   - Any sections left incomplete (missing context or examples)
+   - Confidence level: high (source-verified), medium (inferred from types), low (guessed from names)
+
+## Expected output
+
+- A rewritten README file following the consistent structure
+- A summary of structural changes made
+
+## Safety & constraints
+
+- Never invent features or capabilities the package does not have
+- Never include internal implementation details in the consumer-facing README
+- Do not add empty TODO sections — omit until content exists
+- Preserve any project-specific README sections not covered by the template (e.g., migration guides, troubleshooting)

--- a/skills/fusion-tsdoc-readme/agents/reviewer.agent.md
+++ b/skills/fusion-tsdoc-readme/agents/reviewer.agent.md
@@ -1,0 +1,110 @@
+# Review Council Agent
+
+## When to use
+
+Activated by the orchestrator after TSDoc and README passes are complete. Runs a structured quality review across four dimensions before changes are finalized.
+
+## When not to use
+
+- Do not use as the primary documentation author (use `tsdoc.agent.md` and `readme.agent.md`)
+- Do not use for convention rule lookups (use `fusion-code-conventions`)
+
+## Required inputs
+
+- Modified source files with TSDoc changes
+- Modified README
+- Original source files (for comparison)
+- Package metadata: name, public API surface
+
+## Instructions
+
+Review all documentation changes against four quality dimensions. For each dimension, produce a pass/concern/fail verdict with specific findings.
+
+### 1. Intent extraction
+
+Check whether TSDoc comments explain *why the code exists* and *what problem it solves*, not just what the function signature already says.
+
+**Pass criteria:**
+- Summary lines describe purpose and context, not just "does X"
+- `@param` descriptions explain constraints and edge cases, not just types
+- Complex logic has explanatory comments beyond the tag list
+
+**Common failures:**
+- "Gets the user" → should explain *which* user, *from where*, and *why*
+- `@param id - The ID` → should explain what the ID identifies and its format
+- Missing context for non-obvious design decisions
+
+### 2. Code comprehension
+
+Check whether complex logic is adequately explained for someone reading the code for the first time.
+
+**Pass criteria:**
+- State machines, algorithms, and multi-step processes have explanatory TSDoc or inline comments
+- Side effects are documented (`@throws`, behavioral notes)
+- Non-obvious return values or error states are explained
+
+**Common failures:**
+- Complex reduce/transform chains without explanation
+- Async orchestration without documenting ordering constraints
+- Error handling that silently swallows or transforms errors
+
+### 3. User-facing quality
+
+Check whether the README is useful to a developer discovering the package for the first time.
+
+**Pass criteria:**
+- The description makes sense without prior context about the monorepo
+- Installation and usage examples actually work with the current API
+- The API reference covers the most important exports
+- The README is scannable — headings, tables, and code blocks break up prose
+
+**Common failures:**
+- Description uses internal jargon without explanation
+- Usage examples import from paths that do not exist
+- API table is incomplete or lists internal-only exports
+
+### 4. Retrieval fitness
+
+Check whether the documentation will produce good results in RAG, semantic search, and code search.
+
+**Pass criteria:**
+- TSDoc summaries use domain-specific vocabulary that users would search for
+- README uses the package's key concepts as headings and early-paragraph terms
+- Examples include realistic variable names and scenarios
+- `@example` blocks are self-contained and copy-pasteable
+
+**Common failures:**
+- Generic summaries that could apply to any package ("handles data processing")
+- README description buried after verbose preamble
+- Examples use placeholder values like `foo`, `bar`, `test123`
+
+## Expected output
+
+A structured review report:
+
+```
+## Review: <package-name>
+
+### Intent extraction: PASS | CONCERN | FAIL
+- [findings]
+
+### Code comprehension: PASS | CONCERN | FAIL
+- [findings]
+
+### User-facing quality: PASS | CONCERN | FAIL
+- [findings]
+
+### Retrieval fitness: PASS | CONCERN | FAIL
+- [findings]
+
+### Summary
+- Overall verdict: PASS | NEEDS REVISION
+- Items to fix before finalizing: [list]
+- Items to consider as follow-up: [list]
+```
+
+## Safety & constraints
+
+- Never approve documentation that invents API behavior
+- Flag uncertainty explicitly rather than passing ambiguous documentation
+- Do not block on style preferences — focus on accuracy, completeness, and discoverability

--- a/skills/fusion-tsdoc-readme/agents/tsdoc.agent.md
+++ b/skills/fusion-tsdoc-readme/agents/tsdoc.agent.md
@@ -1,0 +1,55 @@
+# TSDoc Agent
+
+## When to use
+
+Activated by the orchestrator to run a TSDoc improvement pass on a single package. Scans all source files, identifies public exports, and adds or improves TSDoc comments.
+
+## When not to use
+
+- Do not use for README changes (use `readme.agent.md`)
+- Do not use for quality review (use `reviewer.agent.md`)
+- Do not use for single-function TSDoc fixes (use `fusion-code-conventions` directly)
+
+## Required inputs
+
+- Package root path
+- Project conventions discovered by the orchestrator (TSDoc rules, commit format)
+
+## Instructions
+
+1. **Scan source files.** List all `.ts` and `.tsx` files in the package's `src/` directory (or equivalent source root). Exclude test files (`*.test.ts`, `*.spec.ts`, `__tests__/`), build artifacts, and generated files.
+
+2. **Identify public exports.** For each source file, find all exported symbols: functions, classes, interfaces, types, enums, constants, React components, and hooks. Follow the export chain from the package entry point (`index.ts` or `package.json` `exports` field) to determine what is truly public vs. internal.
+
+3. **Classify documentation state.** For each public export:
+   - **Missing**: no TSDoc comment
+   - **Incomplete**: TSDoc present but missing required tags
+   - **Weak**: TSDoc present but restates the name or type without explaining intent
+   - **Adequate**: TSDoc is accurate, complete, and explains intent
+
+4. **Improve documentation.** For each Missing, Incomplete, or Weak export:
+   - Read the implementation to understand what it does and why
+   - Write or rewrite the TSDoc following the project's conventions (or `fusion-code-conventions` TSDoc baseline)
+   - Required tags: summary, `@param`, `@returns`, `@template`, `@throws`, `@example` (where applicable)
+   - The summary must explain *intent and why*, not restate the function signature
+   - `@example` blocks must use realistic values and show expected output
+
+5. **Add `@packageDocumentation`.** If the package entry point lacks a `@packageDocumentation` TSDoc comment, add one that briefly describes the package's purpose.
+
+6. **Report findings.** Return to the orchestrator:
+   - Total public exports found
+   - Exports improved (with before/after classification)
+   - Any exports left as Adequate (no changes needed)
+   - Any exports that could not be documented accurately (ambiguous logic, missing context)
+
+## Expected output
+
+- Modified source files with improved TSDoc on all public exports
+- A summary table of documentation state changes per file
+
+## Safety & constraints
+
+- Never modify source code logic — TSDoc changes only
+- Never invent behavior that is not present in the code
+- Preserve existing accurate documentation
+- Flag exports where intent is ambiguous rather than guessing

--- a/skills/fusion-tsdoc-readme/assets/readme-template.md
+++ b/skills/fusion-tsdoc-readme/assets/readme-template.md
@@ -1,0 +1,46 @@
+# @scope/package-name
+
+[![npm version](https://img.shields.io/npm/v/@scope/package-name)](https://www.npmjs.com/package/@scope/package-name)
+
+Brief description of what the package does, who it is for, and why it exists.
+
+## Features
+
+- Feature one — concrete capability
+- Feature two — concrete capability
+- Feature three — concrete capability
+
+## Installation
+
+```bash
+npm install @scope/package-name
+```
+
+## Usage
+
+```typescript
+import { mainExport } from '@scope/package-name';
+
+const result = mainExport({ /* config */ });
+```
+
+## API
+
+| Export | Description |
+|---|---|
+| `mainExport(config)` | Brief description of the primary export |
+| `HelperType` | Brief description of a supporting type |
+
+## Configuration
+
+> Include this section only when the package has meaningful configuration options.
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `option` | `string` | `"default"` | What this option controls |
+
+## Related packages
+
+> Include this section only when the package is part of a family.
+
+- [`@scope/related-package`](../related-package) — how it relates

--- a/skills/fusion-tsdoc-readme/references/orchestration.md
+++ b/skills/fusion-tsdoc-readme/references/orchestration.md
@@ -1,0 +1,63 @@
+# Multi-Package Orchestration
+
+Guidance for running documentation passes across multiple packages efficiently.
+
+## Batch sizing
+
+Estimate package complexity before deciding batch strategy:
+
+| Package complexity | Approximate exports | Strategy |
+|---|---|---|
+| Small (utility) | < 15 public exports | Inline sequentially — low context cost |
+| Medium (module) | 15–50 public exports | Sub-agent per package when available |
+| Large (framework) | 50+ public exports | Sub-agent per package, split into file groups if needed |
+
+## Sub-agent vs. inline
+
+Use sub-agents (when the runtime supports them) to:
+- Isolate package context — prevents cross-package confusion in TSDoc descriptions
+- Parallelize independent packages — batch 3–5 small packages or 1–2 large packages per round
+- Checkpoint progress — each sub-agent commits its package independently
+
+Use inline sequential processing when:
+- The runtime does not support sub-agents
+- Only 1–3 packages are targeted
+- Packages share significant API surface and benefit from cross-referencing
+
+## Context isolation
+
+Each package pass should start fresh:
+1. Read only the target package's source files and its direct dependencies' type definitions.
+2. Do not carry TSDoc phrasing or README content from a previous package into the next.
+3. Re-read project conventions at the start of each batch (conventions may differ per package in heterogeneous monorepos).
+
+## Progress tracking
+
+For runs covering more than 5 packages:
+
+1. Maintain a tracking list with status per package: `pending`, `in-progress`, `review`, `done`.
+2. After each package, report: package name, exports documented, README sections updated, any review findings.
+3. If a tracking issue exists, update its body or add a progress comment after each batch.
+
+## Token budget awareness
+
+Documentation passes are token-intensive. Budget considerations:
+
+- **TSDoc pass**: ~50–100 tokens per export (reading source + writing TSDoc)
+- **README pass**: ~500–1500 tokens per package (reading + rewriting)
+- **Review pass**: ~200–500 tokens per package
+
+For large monorepos (20+ packages), plan multiple sessions rather than attempting all packages in one context window.
+
+## Error recovery
+
+If a sub-agent fails mid-package:
+1. Check what was committed — partial work may already be pushed.
+2. Resume from the last uncommitted file rather than restarting the package.
+3. If the failure was context-related (too many exports), split the package into file groups and process each group as a separate sub-agent call.
+
+## Commit strategy
+
+- **Per-package commits**: `docs(<package-name>): improve TSDoc and README`
+- **Per-file commits** (only for very large packages): `docs(<package-name>): add TSDoc to <file-group>`
+- Never combine multiple packages in a single commit — keeps history reviewable and revertable.

--- a/skills/fusion-tsdoc-readme/references/readme-structure.md
+++ b/skills/fusion-tsdoc-readme/references/readme-structure.md
@@ -1,0 +1,107 @@
+# README Structure Guide
+
+Standard structure for package READMEs. Adapt section depth to the package's complexity — small utility packages may collapse sections; large framework packages may expand them.
+
+## Required sections (in order)
+
+### 1. Package name and badge row
+
+```markdown
+# @scope/package-name
+
+[![npm version](https://img.shields.io/npm/v/@scope/package-name)](https://www.npmjs.com/package/@scope/package-name)
+```
+
+Use the published package name as the heading. Add relevant badges (npm version, build status, license) on the line below.
+
+### 2. Description
+
+One to three sentences explaining:
+- What the package does (capability, not implementation)
+- Who it is for (target audience or consumer type)
+- Why it exists (the problem it solves or the gap it fills)
+
+Avoid repeating the package name. Write for someone who has never seen this package before.
+
+### 3. Features
+
+Bulleted list of key capabilities. Each bullet should be a concrete, scannable feature — not a vague benefit.
+
+```markdown
+## Features
+
+- Automatic retry with configurable backoff for transient HTTP errors
+- Type-safe request/response wrappers for Fusion API endpoints
+- Built-in token refresh using the Fusion auth module
+```
+
+### 4. Installation
+
+```markdown
+## Installation
+
+\`\`\`bash
+npm install @scope/package-name
+\`\`\`
+```
+
+Show the primary package manager command. Add alternatives (yarn, pnpm, bun) only when the monorepo explicitly supports them.
+
+### 5. Usage
+
+Show realistic, working examples that demonstrate the most common use case. Include:
+- Import statement
+- Minimal setup
+- Expected output or behavior
+
+For packages with multiple entry points, show the primary one first and link to others.
+
+```markdown
+## Usage
+
+\`\`\`typescript
+import { createClient } from '@scope/package-name';
+
+const client = createClient({ baseUrl: '/api/v1' });
+const result = await client.get('/resources');
+\`\`\`
+```
+
+### 6. API reference
+
+Summarize the key public exports with brief descriptions. For large APIs, link to generated docs or a separate API reference page.
+
+```markdown
+## API
+
+| Export | Description |
+|---|---|
+| `createClient(config)` | Creates an HTTP client instance with the given configuration |
+| `useClient(name)` | React hook to access a named client from the framework |
+| `ClientConfig` | Configuration interface for `createClient` |
+```
+
+### 7. Configuration (conditional)
+
+Include only when the package has meaningful configuration options. Show defaults and explain when to override.
+
+### 8. Related packages (conditional)
+
+Include only when the package is part of a family. Link to sibling packages and explain the relationship.
+
+## Optional sections
+
+Add these when they provide genuine value:
+
+- **Migration guide** — when a major version introduced breaking changes
+- **Troubleshooting** — when specific error states are common and non-obvious
+- **Contributing** — when the package accepts contributions and has specific guidelines
+- **License** — when it differs from the monorepo root license
+
+## Anti-patterns
+
+- Do not include a changelog in the README — use `CHANGELOG.md`
+- Do not duplicate the full API surface in prose — summarize and link
+- Do not include internal implementation details — focus on the consumer perspective
+- Do not use "Introduction" or "Overview" as section headings — the description serves that purpose
+- Do not add empty sections with "TODO" — omit them until content exists


### PR DESCRIPTION
## Why

No reusable skill exists for systematic TSDoc and README documentation passes across packages. The workflow was proven effective across a 41-package documentation sprint on `equinor/fusion-framework` (equinor/fusion-core-tasks#599) but required bespoke prompts every time — no consistent quality bar, no orchestration guidance, and no review council.

## Current behavior

- TSDoc enforcement exists only as a sub-concern of `fusion-code-conventions`
- No skill for running systematic documentation passes across multiple packages
- No README structure standard or template for package documentation
- Each documentation session reinvents what "good TSDoc" and "good README" look like

## New behavior

New `fusion-tsdoc-readme` orchestrator skill with:
- **SKILL.md** (180 lines) — repo-aware conventions discovery, TSDoc pass, README pass, review council, and multi-package orchestration workflow
- **agents/tsdoc.agent.md** — scans exports, classifies documentation state, and improves TSDoc
- **agents/readme.agent.md** — assesses README structure and rewrites to consistent format
- **agents/reviewer.agent.md** — four-dimension review council (intent extraction, code comprehension, user-facing quality, retrieval fitness)
- **references/readme-structure.md** — standard README section structure
- **references/orchestration.md** — multi-package batching, context isolation, and token budget strategy
- **assets/readme-template.md** — copy-pasteable README scaffold

Delegates TSDoc convention rules to `fusion-code-conventions` (declared in `metadata.skills`) rather than duplicating them.

## References

- Issue(s): Resolves equinor/fusion-core-tasks#702
- Related PR(s): —
- Docs / specs: Prior art from equinor/fusion-core-tasks#599 (41-package doc pass)

## Reviewer focus

- Start here (files/areas): [skills/fusion-tsdoc-readme/SKILL.md](skills/fusion-tsdoc-readme/SKILL.md)
- Verify these behavior changes: Skill appears in `npx -y skills add . --list` output, passes `validate:skills` and `validate:ownership`
- Risky or security-sensitive parts: None — read-only documentation workflow skill, no scripts

## Self review checklist

- [x] I scoped this PR to one clear purpose.
- [x] I followed [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I did not include secrets, credentials, or sensitive data.
- [x] I reviewed my own diff for clarity and unintended changes.