### PR TITLE
fix(fusion-issue-authoring): make draft location flexible, respect user preferences

### DIFF
--- a/.changeset/fix-issue-authoring-draft-path-flexibility.md
+++ b/.changeset/fix-issue-authoring-draft-path-flexibility.md
@@ -1,0 +1,9 @@
+---
+"fusion-issue-authoring": patch
+---
+
+Make draft location flexible — check user preferences and session memory before defaulting to `.tmp/`
+
+- Step 4 now checks user preferences and session memory for a preferred draft location
+- Asks once when intent is ambiguous and remembers the answer for the session
+- Falls back to `.tmp/{TYPE}-{CONTEXT}.md` only when no preference is found

--- a/skills/fusion-issue-authoring/SKILL.md
+++ b/skills/fusion-issue-authoring/SKILL.md
@@ -93,7 +93,7 @@ Do not run repeated broad duplicate scans unless the user changes scope/title ma
 
 ### Step 4 — Draft first
 
-Draft in `.tmp/{TYPE}-{CONTEXT}.md` using GitHub Flavored Markdown.
+Before writing, check user preferences and session memory for a preferred draft location. If a stored preference exists, use it. If no preference is found and the intent is ambiguous, ask once and remember the answer for the session. Default to `.tmp/{TYPE}-{CONTEXT}.md` when no preference is found and there is nothing to ask about. Write the draft using GitHub Flavored Markdown.
 
 ### Step 5 — Review and confirm
 


### PR DESCRIPTION
## Why

The draft location in `fusion-issue-authoring` was hardcoded to `.tmp/{TYPE}-{CONTEXT}.md`, ignoring any user or session memory preferences. This made the skill unnecessarily rigid and inconsistent with how other per-session preferences (labels, assignees) are already handled.

## Current behavior

Step 4 always writes the draft to `.tmp/{TYPE}-{CONTEXT}.md` regardless of user preferences or session memory.

## New behavior

Step 4 now checks user preferences and session memory before writing the draft. If a preferred location is stored, it is used. If intent is ambiguous and no preference exists, the skill asks once and remembers the answer for the session. Falls back to `.tmp/{TYPE}-{CONTEXT}.md` only when no preference is found and there is nothing to clarify.

## References

- Issue(s): none
- Related PR(s): none
- Docs / specs: none

## Reviewer focus

- Start here: `skills/fusion-issue-authoring/SKILL.md` — Step 4
- Verify these behavior changes: draft is written to user-preferred location when a preference is stored; skill asks once when ambiguous
- Risky or security-sensitive parts: none

## Self review checklist

- [x] I scoped this PR to one clear purpose.
- [x] I followed [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I did not include secrets, credentials, or sensitive data.
- [x] I reviewed my own diff for clarity and unintended changes.
