### PR TITLE
Issue authoring - add project and stage publish gates

### DIFF
--- a/.changeset/issue-authoring-project-stage-gates.md
+++ b/.changeset/issue-authoring-project-stage-gates.md
@@ -1,0 +1,12 @@
+---
+"fusion-issue-authoring": minor
+---
+
+Add explicit project and stage gating to issue authoring workflow.
+
+- Extend required inputs and shared gates to include project placement intent and stage/status selection
+- Update mutation order guidance to include project placement after issue create/update
+- Add fallback guidance when project/stage MCP mutations are unavailable
+- Expand clarifying question bank with project and stage prompts
+
+resolves equinor/fusion-skills#138

--- a/skills/fusion-issue-authoring/SKILL.md
+++ b/skills/fusion-issue-authoring/SKILL.md
@@ -56,6 +56,8 @@ Collect before publishing:
 - Issue intent/context
 - Issue type (Bug, Feature, User Story, Task)
 - Existing issue number/url when updating
+- Project placement intent (add to project or skip) and target project selection when applicable
+- Project stage/status intent when project placement is selected (for example Backlog, Doing, Done)
 - Repository label set (or confirmation that labels are intentionally skipped). Cache the full label set per repository for the active session and filter locally instead of validating labels one by one. Prefer host session memory when available; otherwise use a `.tmp/` cache file that is never committed.
 - Parent/related issue links and dependency direction (sub-issue vs blocking)
 - Assignee preference (assign to user, specific person, or leave unassigned). Reuse cached assignee-candidate results for the active session and skip candidate searches when the user already gave `@me` or an exact login.
@@ -106,6 +108,9 @@ Before writing, check user preferences and session memory for a preferred draft 
 Before mutation, confirm:
 - labels (only labels that exist in the target repo)
 - assignee intent (`@me`, specific login, or unassigned)
+- project intent (add to project or skip)
+- project target when project intent is "add"
+- stage/status intent when project placement is selected
 
 Shared gate cache policy:
 - On the first label lookup for `owner/repo`, fetch the repository label set once and cache it for the active session. Prefer `/memories/session/<owner>-<repo>-labels.json` when the host exposes session memory; otherwise use `.tmp/issue-authoring-labels-<owner>-<repo>.json`.
@@ -120,13 +125,19 @@ Shared gate cache policy:
 After explicit confirmation, execute MCP mutations in this order:
 1. `mcp_github::issue_write` create/update with the full known payload (`title`, `body`, and include `labels`, `assignees`, `type` only when supported)
 2. Optional single follow-up `mcp_github::issue_write` only when required fields were unknown in step 1 and become available later
-3. `mcp_github::sub_issue_write` only when relationship/order changes are requested
-4. `mcp_github::add_issue_comment` only when blocker/status notes are explicitly requested
+3. Project placement mutation only when requested by user (add issue to selected project and set requested stage/status when supported)
+4. `mcp_github::sub_issue_write` only when relationship/order changes are requested
+5. `mcp_github::add_issue_comment` only when blocker/status notes are explicitly requested
 
 If mutation fails due to missing MCP server/auth/config:
 - explain the failure clearly
 - guide user to setup steps in `references/mcp-server.md`
 - retry after user confirms setup is complete
+
+If project/stage mutation is requested but not supported by available MCP tools:
+- explain the limitation clearly
+- ask whether to continue with issue creation/update without project placement
+- provide a follow-up path to add project/stage after publish
 
 Rate-limit behavior:
 - Detect and report rate-limit failures clearly (`API rate limit exceeded`, `secondary rate limit`, GraphQL quota exhaustion).
@@ -172,6 +183,8 @@ Fallback template locations:
 - Template source used (repository template path or fallback asset path)
 - Proposed title, body summary, and labels
 - Issue type plan
+- Project placement plan (project or skip)
+- Stage/status plan when project placement is selected
 - Dependency plan (order + proposed sub-issue/blocking links)
 - Assignee plan (who will be assigned, or explicit unassigned decision)
 - Explicit status: `Awaiting user content approval` before any publish/update command

--- a/skills/fusion-issue-authoring/references/instructions.md
+++ b/skills/fusion-issue-authoring/references/instructions.md
@@ -8,7 +8,7 @@ Goal: create clear GitHub issues fast, with draft-first review and safe mutation
 - Use full issue references (`owner/repo#123`).
 - Never mutate before explicit publish confirmation.
 - Ask only essential clarifying questions.
-- Resolve repository and labels before mutation.
+- Resolve repository, project intent, and labels before mutation.
 - Prefer MCP tools first and avoid ad hoc GitHub API/GraphQL retries when an MCP equivalent exists.
 
 ## Low-token strategy
@@ -39,6 +39,7 @@ Routing is repo-specific. When no explicit repository is given, read the active 
 8. Mutate via MCP in this order:
 	- `mcp_github::issue_write` create/update with full known payload (labels/assignees/type when supported)
 	- optional single follow-up `mcp_github::issue_write` only for fields unavailable in the first call
+	- project placement and stage/status mutation when requested and supported
 	- `mcp_github::sub_issue_write` for sub-issue ordering/links only when changes are needed
 	- `mcp_github::add_issue_comment` for blocker/status notes only when requested
 
@@ -88,6 +89,13 @@ Quick check:
 - If the user gives `@me` or an exact GitHub login, do not run `mcp_github::search_users`.
 - When assignee search is needed, cache the result set for the active session keyed by owner/repo (or owner) and query. Prefer `/memories/session/{owner}-{repo}-assignee-candidates.json` or `/memories/session/{owner}-assignee-candidates.json`; otherwise use `.tmp/issue-authoring-assignee-candidates-{owner}-{repo}.json`.
 - If the host exposes repository contributors or organization members, hydrate that cache once and reuse it; otherwise reuse the first `mcp_github::search_users` result for the same query.
+
+## Project and stage gate
+
+- Ask project intent explicitly: add to project or skip.
+- If "add", ask which project should receive the issue.
+- Ask desired stage/status when project placement is selected.
+- If project/stage mutation is unsupported in available MCP tools, ask whether to continue without project placement and provide a follow-up path.
 
 ## MCP reference
 

--- a/skills/fusion-issue-authoring/references/mcp-server.md
+++ b/skills/fusion-issue-authoring/references/mcp-server.md
@@ -12,6 +12,7 @@ Use this file for GitHub MCP-specific tools and payload examples.
 - `mcp_github::search_users`: search users for assignment candidates.
 - `mcp_github::add_issue_comment`: add comment to issue.
 - `mcp_github::list_issue_types`: list available issue types.
+- project-capable MCP tools to add issues to a project and set stage/status (exact tool names can vary by MCP server/client build).
 
 ## High-cost operations and mitigation
 
@@ -76,6 +77,13 @@ There is no dedicated Issues MCP tool in this set for setting blocking/blocked l
 
 - Prefer `mcp_github::sub_issue_write` to organize issues in a logical execution order.
 - Use `mcp_github::add_issue_comment` (or issue body text) to document blocker relationships when needed.
+
+## Project and stage placement note
+
+Some GitHub MCP deployments expose project item mutations (add to project and update status field), while others do not.
+
+- When available, use project-capable MCP mutations after issue create/update to place the issue in the selected project and requested stage.
+- When unavailable, keep issue creation/update flow intact, inform the user that project/stage placement was skipped, and provide a follow-up path.
 
 ## `type` parameter rule
 
@@ -202,8 +210,9 @@ Use either `after_id` or `before_id` for reprioritization.
 
 1. `mcp_github::issue_write` create/update with full known fields (`title`, `body`, `labels`, `assignees`, optional `type`) using cache-backed label/assignee data when available
 2. Optional single follow-up `mcp_github::issue_write` only for fields that were unavailable in step 1
-3. `mcp_github::sub_issue_write` add/reprioritize children in execution order only when linkage changed
-4. Optional: `mcp_github::add_issue_comment` to record blocker context when requested
+3. Optional project placement and stage/status mutation when requested and supported
+4. `mcp_github::sub_issue_write` add/reprioritize children in execution order only when linkage changed
+5. Optional: `mcp_github::add_issue_comment` to record blocker context when requested
 
 ## Rate-limit fallback behavior
 

--- a/skills/fusion-issue-authoring/references/questions.md
+++ b/skills/fusion-issue-authoring/references/questions.md
@@ -17,6 +17,9 @@ Use the smallest set of questions needed to draft a useful issue.
 - What are the success criteria?
 - Which labels from this repository should be applied (or should we skip labels)?
 - Should this be assigned, and if so to whom (`@me` or specific login)?
+- Should this issue be added to a project?
+- If yes, which project should it be added to?
+- If added to a project, which stage/status should it start in (for example Backlog, Doing, Done)?
 
 ## Draft review gate (before publish/update)
 


### PR DESCRIPTION
## Why

`fusion-issue-authoring` did not explicitly require project placement and stage/status selection as shared publish gates, which caused inconsistent issue placement in project boards.

## Current behavior

Before this PR:
- Assignee handling is documented as a shared gate, but project placement/stage gating is not.
- Question bank does not ask for project and stage/status choices.
- Mutation order guidance does not include project placement as a first-class step.

## New behavior

After this PR:
- `fusion-issue-authoring` explicitly asks for project placement intent and target stage/status before mutation.
- References and question bank include project + stage prompts.
- Mutation order includes project placement/stage updates after issue create/update when supported.
- Fallback behavior is documented for environments where project/stage mutation is unavailable.

## References

- Issue(s): equinor/fusion-skills#138
- Related PR(s):
- Docs / specs:

## Reviewer focus

- Start here (files/areas):
  - `skills/fusion-issue-authoring/SKILL.md`
  - `skills/fusion-issue-authoring/references/instructions.md`
  - `skills/fusion-issue-authoring/references/questions.md`
  - `skills/fusion-issue-authoring/references/mcp-server.md`
  - `.changeset/issue-authoring-project-stage-gates.md`
- Verify these behavior changes:
  - project and stage are now explicit gating questions
  - mutation flow includes project placement in sequence
  - fallback path is clear when project tools are unavailable
- Risky or security-sensitive parts:
  - docs-only change, no runtime script changes

## Self review checklist

- [x] I scoped this PR to one clear purpose.
- [x] I followed [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I did not include secrets, credentials, or sensitive data.
- [x] I reviewed my own diff for clarity and unintended changes.
