### PR TITLE
feat(skills): add fusion-backend-dev shared skill for API consumption patterns

### DIFF
--- a/.changeset/fusion-backend-dev-initial.md
+++ b/.changeset/fusion-backend-dev-initial.md
@@ -14,4 +14,4 @@ Add new shared skill for consuming and understanding Fusion backend services
 - Integrates with fusion-research skill for code discovery via MCP
 - Published as active skill; suitable for shared consumption across teams
 
-Used by backend development workflows and service integration tasks.
+Used by backend API consumption, service integration, and backend contract understanding workflows.

--- a/.changeset/fusion-backend-dev-initial.md
+++ b/.changeset/fusion-backend-dev-initial.md
@@ -1,0 +1,17 @@
+---
+"fusion-backend-dev": minor
+---
+
+Add new shared skill for consuming and understanding Fusion backend services
+
+- Comprehensive references on API contracts, versioning, and error handling
+- Authorization patterns covering Azure AD, RBAC, and error scenarios
+- Validation layer patterns, error codes, and retry strategies
+- Async patterns for events, webhooks, polling, and idempotent processing
+- Integration patterns for cross-service calls, resilience, and caching
+- CQRS reference guide for command/query patterns and handlers
+- Follow-up questions asset for clarifying ambiguous requests
+- Integrates with fusion-research skill for code discovery via MCP
+- Marked experimental; suitable for shared consumption across teams
+
+Used by backend development workflows and service integration tasks.

--- a/.changeset/fusion-backend-dev-initial.md
+++ b/.changeset/fusion-backend-dev-initial.md
@@ -12,6 +12,6 @@ Add new shared skill for consuming and understanding Fusion backend services
 - CQRS reference guide for command/query patterns and handlers
 - Follow-up questions asset for clarifying ambiguous requests
 - Integrates with fusion-research skill for code discovery via MCP
-- Marked experimental; suitable for shared consumption across teams
+- Published as active skill; suitable for shared consumption across teams
 
 Used by backend development workflows and service integration tasks.

--- a/.changeset/fusion-mcp-backend-tool-listing.md
+++ b/.changeset/fusion-mcp-backend-tool-listing.md
@@ -1,0 +1,8 @@
+---
+"fusion-mcp": patch
+---
+
+Document backend code tools in the Fusion MCP setup guide.
+
+- Add `search_backend_code` to retrieval tool examples
+- Add `get_backend_symbol` and `list_backend_projects` in the available backend tooling list

--- a/.changeset/fusion-research-backend-code-routing.md
+++ b/.changeset/fusion-research-backend-code-routing.md
@@ -1,0 +1,10 @@
+---
+"fusion-research": minor
+---
+
+Add backend-code routing support to fusion-research.
+
+- Add backend-code domain classification and agent dispatch guidance
+- Add backend-code research agent for C# and backend service implementation questions
+- Add backend-code query reference with evidence-first search lanes
+- Extend compatibility and MCP suggestions with backend code search support

--- a/skills/.experimental/fusion-mcp/SKILL.md
+++ b/skills/.experimental/fusion-mcp/SKILL.md
@@ -56,7 +56,8 @@ If details are missing, ask concise follow-up questions first.
    - Fusion-oriented MCP capabilities for retrieval and workflow support
    - tool surface may evolve over time as the server is a PoC
    - examples today may include retrieval, index guidance, metadata summaries, and skill discovery
-   - retrieval tools: `search_framework`, `search_docs`, `search_eds`, `search_skills`, `search_indexes`
+   - retrieval tools: `search_framework`, `search_docs`, `search_eds`, `search_skills`, `search_indexes`, `search_backend_code`
+   - backend code tools: `get_backend_symbol`, `list_backend_projects`
    - skill advisory: `skills`, `skills_index_status`
 2. Use the official README quick start as source of truth, then present a minimal 2-step setup path:
    - choose image source: GHCR release image or local build

--- a/skills/.system/fusion-research/SKILL.md
+++ b/skills/.system/fusion-research/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: fusion-research
-description: 'Source-backed research orchestrator for the Fusion ecosystem. Routes to the correct research agent based on question type. Returns source-backed evidence only; will not invent Framework behavior, component APIs, skill catalog relationships, or platform guidance. USE FOR: any research question needing source-backed evidence about Fusion Framework APIs, EDS components, the Fusion skill catalog, or Fusion platform documentation. DO NOT USE FOR: implementing code changes, installing or editing skills, MCP setup or troubleshooting, or inventing Fusion behavior without evidence.'
+description: 'Source-backed research orchestrator for the Fusion ecosystem. Routes to the correct research agent based on question type. Returns source-backed evidence only; will not invent Framework behavior, component APIs, skill catalog relationships, platform guidance, or backend implementation details. USE FOR: any research question needing source-backed evidence about Fusion Framework APIs, EDS components, the Fusion skill catalog, Fusion platform documentation, or backend service implementation. DO NOT USE FOR: implementing code changes, installing or editing skills, MCP setup or troubleshooting, or inventing Fusion behavior without evidence.'
 license: MIT
-compatibility: Works best with Fusion MCP. Dispatches to `agents/framework.agent.md` for `mcp_fusion_search_framework`, `agents/eds.agent.md` for `mcp_fusion_search_eds`, `agents/skills.agent.md` for `mcp_fusion_search_skills`, and `agents/docs.agent.md` for `mcp_fusion_search_docs`. If MCP is unavailable, state that clearly rather than guessing.
+compatibility: Works best with Fusion MCP. Dispatches to `agents/framework.agent.md` for `mcp_fusion_search_framework`, `agents/eds.agent.md` for `mcp_fusion_search_eds`, `agents/skills.agent.md` for `mcp_fusion_search_skills`, `agents/docs.agent.md` for `mcp_fusion_search_docs`, and `agents/backend-code.agent.md` for `mcp_fusion_search_backend_code`. If MCP is unavailable, state that clearly rather than guessing.
 metadata:
-  version: "0.3.0"
+  version: "0.4.0"
   status: experimental
   owner: "@equinor/fusion-core"
   tags:
@@ -16,6 +16,9 @@ metadata:
     - eds
     - skills
     - docs
+    - backend
+    - csharp
+    - services
     - platform-guidance
   mcp:
     suggested:
@@ -23,6 +26,7 @@ metadata:
       - mcp_fusion_search_eds
       - mcp_fusion_search_docs
       - mcp_fusion_search_skills
+      - mcp_fusion_search_backend_code
       - mcp_fusion_skills
 ---
 
@@ -79,6 +83,7 @@ Determine which domain the question belongs to:
 | **EDS** | EDS component props, usage examples, accessibility, design tokens | [`agents/eds.agent.md`](agents/eds.agent.md) |
 | **Skills** | Skill catalog lookup, scope boundaries, companion/orchestrator relationships | [`agents/skills.agent.md`](agents/skills.agent.md) |
 | **Docs** | Fusion platform concepts, onboarding, platform operations, governance, non-implementation guidance | [`agents/docs.agent.md`](agents/docs.agent.md) |
+| **Backend Code** | C# service implementations, interfaces, CQRS patterns, authorization, validation, cross-service APIs | [`agents/backend-code.agent.md`](agents/backend-code.agent.md) |
 
 If the question spans multiple domains, answer each domain separately using the appropriate agent in sequence.
 
@@ -88,6 +93,7 @@ If the question spans multiple domains, answer each domain separately using the 
 - EDS questions → follow [`agents/eds.agent.md`](agents/eds.agent.md).
 - Skills questions → follow [`agents/skills.agent.md`](agents/skills.agent.md).
 - Docs questions → follow [`agents/docs.agent.md`](agents/docs.agent.md).
+- Backend code questions → follow [`agents/backend-code.agent.md`](agents/backend-code.agent.md).
 
 If the runtime supports skill-local agents, invoke the agent directly. Otherwise, apply the agent's instructions inline.
 
@@ -100,12 +106,13 @@ Use the structure in [assets/source-backed-answer-template.md](assets/source-bac
 
 ## Research agents
 
-This skill includes four research agents in `agents/`. Each covers one Fusion research domain with its own query patterns and evidence checklist.
+This skill includes five research agents in `agents/`. Each covers one Fusion research domain with its own query patterns and evidence checklist.
 
 - **[`agents/framework.agent.md`](agents/framework.agent.md)** — source-backed answers about Fusion Framework hooks, packages, modules, and cookbook examples. Uses `mcp_fusion_search_framework`.
 - **[`agents/eds.agent.md`](agents/eds.agent.md)** — source-backed answers about EDS component props, usage, accessibility, and design tokens. Uses `mcp_fusion_search_eds`.
 - **[`agents/skills.agent.md`](agents/skills.agent.md)** — source-backed answers about the Fusion skill catalog: what skills exist, their scope, and how they relate. Uses `mcp_fusion_search_skills`.
 - **[`agents/docs.agent.md`](agents/docs.agent.md)** — source-backed answers about Fusion platform concepts, onboarding, operations, and governance. Uses `mcp_fusion_search_docs`.
+- **[`agents/backend-code.agent.md`](agents/backend-code.agent.md)** — source-backed answers about Fusion backend service implementations: C# services, interfaces, CQRS patterns, authorization, and cross-service integrations. Uses `mcp_fusion_search_backend_code`.
 
 ## Assets
 

--- a/skills/.system/fusion-research/SKILL.md
+++ b/skills/.system/fusion-research/SKILL.md
@@ -4,7 +4,7 @@ description: 'Source-backed research orchestrator for the Fusion ecosystem. Rout
 license: MIT
 compatibility: Works best with Fusion MCP. Dispatches to `agents/framework.agent.md` for `mcp_fusion_search_framework`, `agents/eds.agent.md` for `mcp_fusion_search_eds`, `agents/skills.agent.md` for `mcp_fusion_search_skills`, `agents/docs.agent.md` for `mcp_fusion_search_docs`, and `agents/backend-code.agent.md` for `mcp_fusion_search_backend_code`. If MCP is unavailable, state that clearly rather than guessing.
 metadata:
-  version: "0.4.0"
+  version: "0.3.0"
   status: experimental
   owner: "@equinor/fusion-core"
   tags:

--- a/skills/.system/fusion-research/agents/backend-code.agent.md
+++ b/skills/.system/fusion-research/agents/backend-code.agent.md
@@ -1,0 +1,62 @@
+# Backend Code Research Agent
+
+## Role
+
+Use this agent when the research question is about Fusion backend implementation: C# services, class hierarchies, interfaces, implementation patterns, or architectural decisions in backend repositories.
+
+When the question belongs to Framework TypeScript APIs, use `agents/framework.agent.md`. When it belongs to platform concepts or onboarding, use `agents/docs.agent.md`.
+
+## MCP tooling
+
+Prefer `mcp_fusion_search_backend_code` for all backend code questions. This searches across:
+- C# service implementations (fusion-core-services)
+- Shared library interfaces (fusion-libraries)
+- Function implementations (fusion-functions)
+- Integration patterns (fusion-integration-lib)
+- Core infrastructure (fusion-dev-tools, fusion-mcp)
+
+## Search lanes
+
+Recommended search patterns by question type:
+
+| Lane | Pattern | Example Query |
+| --- | --- | --- |
+| **Interface/Contract** | Service interface, method signatures, abstractions | "IPeopleApiClient interface" |
+| **Implementation** | Class implementation, MediatR handlers, service logic | "How does People service update profiles" |
+| **Pattern/Architecture** | CQRS handlers, authorization, validation, middleware | "MediatR command pattern in services" |
+| **Dependency Graph** | Service dependencies, API integrations, cross-service calls | "How does Org service call People API" |
+| **Error Handling** | Exception handling, validation, response mapping | "How are validation errors handled in services" |
+
+## Process
+
+1. Confirm the question is about backend implementation (C#, services, infrastructure), not Framework or platform concepts.
+2. Choose the search lane above that matches the question type.
+3. Call `mcp_fusion_search_backend_code` with the user's wording plus relevant service name, interface name, or architectural term.
+4. Start small — `top: 3` to `top: 5`. Capture `metadata.repository`, `metadata.service`, `metadata.filePath`, the excerpt, and any declaration details.
+5. If the first pass is weak or ambiguous, do **one refinement pass only**:
+   - Add the exact class or interface name.
+   - Narrow the service (people, org, context, etc.).
+   - Switch lanes (interface → implementation, or single service → cross-service call).
+6. If still weak after refinement, stop and state uncertainty plainly.
+7. Build the answer from evidence only.
+   - Prefer one to three sources.
+   - Separate confirmed facts from inference.
+   - Quote the exact method signature or implementation snippet when relevant.
+   - Note any inherited or composed dependencies.
+
+## Evidence checklist
+
+Before including a source in the answer:
+- captured `metadata.repository` (which Fusion repo the code lives in)
+- captured `metadata.service` (which service/package, e.g., "Fusion.Services.People")
+- captured `metadata.filePath` (path to the file within the repo)
+- extracted the minimal code snippet that supports the claim
+- noted any interface or base class dependencies
+
+## Safety
+
+Never:
+- invent service methods, interfaces, or behaviors not found in retrieved sources
+- claim backend implementation evidence exists when MCP is unavailable or results are weak
+- use Framework or platform docs as proof of backend architectural decisions
+- assume behavior from similar code — verify the exact implementation in context

--- a/skills/.system/fusion-research/references/backend-code.query.md
+++ b/skills/.system/fusion-research/references/backend-code.query.md
@@ -1,0 +1,109 @@
+# Backend Code Search Reference
+
+## Overview
+
+Backend code search indexes C# implementations across Fusion services, libraries, and infrastructure. Use these search patterns when researching service implementations, API contracts, architectural patterns, or cross-service interactions.
+
+## Search lanes
+
+| Lane | Focus | Example Queries | Evidence Type |
+| --- | --- | --- | --- |
+| **Interface/Abstraction** | Service interfaces, contract definitions, API abstractions | "IPeopleApiClient", "IAuthorizationService", "interface definition" | C# interface declaration with method signatures and XML docs |
+| **Class Implementation** | Concrete implementations, controllers, handlers, business logic | "PeopleService implementation", "PersonController", "class that handles" | C# class with implementation details, inheritance chain, dependencies |
+| **CQRS Handler** | MediatR commands, queries, notifications and their handlers | "GetPersonCommand handler", "CreatePositionCommand", "query that retrieves" | C# command/query with handler, validation, authorization |
+| **Authorization Pattern** | Role-based checks, authorization requirements, security validation | "How authorization works", "role check", "authorization requirement" | Authorization code, requirement definitions, role checks |
+| **Validation Pattern** | FluentValidation rules, input validation, business rules | "Person validation", "validate email", "validation rules" | Validator classes, validation pipelines, error messages |
+| **Cross-Service Call** | API client usage, service-to-service communication, HttpClient patterns | "How Org service calls People API", "calls to external service", "integration" | API client interface, method calls with URL/parameter construction |
+| **Configuration** | Startup configuration, dependency injection, options patterns | "How is authentication configured", "options binding", "DI setup" | Startup.cs snippets, AddOptions patterns, ServiceCollection extensions |
+| **Database Query** | Entity Framework queries, repository patterns, data access | "How person data is queried", "database access", "query performance" | EF Core queries, LINQ expressions, migration context |
+| **Event Handling** | Domain events, service bus integration, event subscription patterns | "How events are published", "event subscription", "async integration" | Event classes, handlers, publish/subscribe code |
+
+## Proven search starters
+
+When you don't know the exact service or method, start with high-level intent:
+
+```
+"How does fusion-core-services handle authorization for sensitive endpoints"
+→ Returns authorization handlers, requirement definitions, Startup config
+
+"What's the pattern for validating input in fusion services"
+→ Returns FluentValidation classes, validator registrations, error handling
+
+"How do Fusion services integrate with external APIs"
+→ Returns HttpClient setup, API client interfaces, authentication patterns
+
+"How is the People service structured"
+→ Returns Controllers, CQRS handlers, Domain models, DbContext
+```
+
+## Query construction tips
+
+1. **Use service names**: "fusion-core-services", "fusion-libraries", "people", "org", "context"
+2. **Use architectural terms**: "IRequest handler", "command", "query", "validator", "controller"
+3. **Use intent verbs**: "how is X implemented", "what pattern does Y use", "does X support Z"
+4. **Add context**: specific API version, scenario, or related entity helps narrow results
+
+## Evidence capture
+
+For backend code answers, always capture:
+
+| Metadata | Meaning | Captured Example |
+| --- | --- | --- |
+| `repository` | Fusion repository name | `fusion-core-services` |
+| `service` | Service/package name | `Fusion.Services.People` |
+| `filePath` | Path to file in repo | `src/Fusion.Services.People/Controllers/PeopleController.cs` |
+| `declarationName` | Type, method, or symbol | `GetPersonById` |
+| `declarationKind` | C# declaration type | `method`, `class`, `interface` |
+| Code snippet | Minimal code that proves the claim | The actual code lines quoted |
+
+## Weak signal indicators
+
+Stop and state uncertainty if:
+- Search returns no results for the service/method you're looking for
+- Results are from unrelated services (e.g., Org service results when querying People service)
+- Code snippets are incomplete (truncated methods, missing context)
+- Results don't clearly answer the "how" or "why" part of the question after one refinement
+
+Example: _"I found references to PeopleService but not the specific implementation of profile update logic. To complete this answer, I'd need to verify the UpdateProfile method locally."_
+
+## Lane examples by question type
+
+### "How does the authorization work?"
+
+**Lane:** Authorization Pattern  
+**Query:** `"authorization requirement in fusion-core-services" + "role-based access"`  
+**Expected result types:**
+- Authorization handler classes
+- Requirement builder extensions
+- Startup configuration showing authorization pipelines
+- Example authorize attributes on controllers
+
+### "How do services call external APIs?"
+
+**Lane:** Cross-Service Call  
+**Query:** `"how fusion services integrate with external API" + "HttpClient"` OR `"API client abstraction"`  
+**Expected result types:**
+- API client interface definitions
+- HttpClient factory setup
+- Example service-to-service calls with URL construction
+- Authentication header injection
+
+### "What's the pattern for validating user input?"
+
+**Lane:** Validation Pattern  
+**Query:** `"FluentValidation" + "fusion-core-services"` OR `"validation rule"`  
+**Expected result types:**
+- Validator classes inheriting from AbstractValidator<T>
+- Validation pipeline registration in Startup
+- Error response mappings
+- Example rule chains
+
+### "How are domain events published?"
+
+**Lane:** Event Handling  
+**Query:** `"domain event" + "publish" + "async messaging"` OR `"INotification"`  
+**Expected result types:**
+- Domain event classes
+- MediatR notification definitions
+- Event handler implementations
+- Service Bus or event bus integration code

--- a/skills/fusion-backend-dev/SKILL.md
+++ b/skills/fusion-backend-dev/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: fusion-backend-dev
+description: 'Guides consumption and understanding of Fusion backend services, APIs, and patterns for frontend/client developers, integrators, and architects. Shows reference implementations, explains architectural decisions, and clarifies contracts. USE FOR: understanding Fusion backend APIs, learning implementation patterns, exploring reference code, choosing the right integration point, and understanding authorization/validation/async patterns. DO NOT USE FOR: modifying backend services, creating new endpoints, database changes, or backend-specific development (use fusion-services-develop or backend service repo instead).'
+license: MIT
+compatibility: Works best with Fusion MCP. Requires mcp_fusion_search_backend_code for reference code discovery. Frontend/client developers should also install fusion-research for deeper architectural context.
+metadata:
+  version: "0.1.0"
+  status: experimental
+  owner: "@equinor/fusion-core"
+  skills:
+    - fusion-research
+  tags:
+    - fusion-backend
+    - api-consumption
+    - patterns
+    - architecture
+    - reference-implementation
+    - csharp
+  mcp:
+    suggested:
+      - mcp_fusion_search_backend_code
+      - mcp_fusion_research
+---
+
+# Fusion Backend Consumption
+
+## When to use
+
+Use this skill when you need to understand how Fusion backend services work, what APIs are available, how to integrate with them, or understand the architectural patterns behind them.
+
+Typical triggers:
+- "How do I call the People API?"
+- "Show me an example of how the authorization pattern works"
+- "What's the contract for the Org service?"
+- "How do services handle validation errors?"
+- "What async/messaging patterns does Fusion use?"
+- "Can I see a reference implementation of a CQRS handler?"
+- "How do services integrate with external APIs?"
+- "What authentication/authorization requirements do I need to know?"
+- "Show me how events flow through the system"
+- "What's the pattern for cross-service calls?"
+- "How should I structure my API client?"
+- "Where should I call the Context API?"
+- "What's the difference between a command and a query in Fusion?"
+
+Implicit triggers:
+- User is building a frontend/client app and needs to understand backend contracts
+- User is integrating with Fusion APIs and needs patterns
+- User is designing an architecture and wants to understand backend best practices
+- User wants to learn from existing Fusion service implementations
+
+## When not to use
+
+Do not use this skill for:
+- **Creating or modifying backend services** — those are backend service development tasks (use the service-specific repo skill, not this one)
+- **Adding new endpoints or API operations** — backend service development
+- **Database schema changes or migrations** — backend development
+- **Authorization requirement definitions** — backend development (this skill shows what exists, not defining new requirements)
+- **Pure architecture discussions without code references** — use fusion-research or ADR-focused skills instead
+- **Selecting between Fusion Framework alternatives** — use fusion-research or fusion-app-react-dev instead
+
+## Required inputs
+
+### Mandatory
+
+- **What you're trying to do**: clear description of the integration point, use case, or pattern you're exploring
+- **Your role/context**: Are you building a frontend app? Integrating externally? Designing architecture?
+
+### Conditional
+
+- When comparing patterns: which two options you're deciding between
+- When consuming an API: what operation/scenario (CRUD, async, real-time, etc.)
+- When integrating: external system name and direction of flow (calling out vs being called)
+
+## Instructions
+
+### Step 1 — Clarify consumption context
+
+Before searching for code, understand what you need:
+
+1. **Integration point**: Are you calling a backend API? Reading event messages? Implementing a webhook? Integrating with an external system?
+2. **Your boundaries**: Are you a frontend developer? Backend developer in another service? External integrator? Architect?
+3. **Scope of understanding**: Do you need a single API contract? A full pattern? A reference implementation? Architectural tradeoffs?
+
+Use `assets/follow-up-questions.md` if the user's intent is unclear.
+
+### Step 2 — Search for reference implementation
+
+Use `mcp_fusion_search_backend_code` to locate existing patterns:
+
+1. Call with high-level intent: "How People service exposes authorization" or "Cross-service API integration patterns"
+2. Start with `top: 3-5` results
+3. Capture `metadata.repository`, `metadata.service`, `metadata.filePath`
+4. Extract minimal code snippets that show the pattern (method signature, type contract, authorization check)
+5. If results are unclear, refine once:
+   - Add specific service name or interface
+   - Narrow to specific layer (controller, handler, client interface)
+   - Try a different phrase focusing on the outcome rather than implementation details
+
+### Step 3 — Explain the pattern
+
+Use the evidence from Step 2 to build your answer:
+
+1. **State the pattern clearly**: What is the service doing? What contract does it expose?
+2. **Show the reference code**: Quote the relevant snippet with file path and line range
+3. **Explain the constraints**: What preconditions? Authorization? Error handling? Async behavior?
+4. **Relate to your use case**: How would you apply this pattern to your problem?
+5. **Surface tradeoffs or alternatives** if they exist:
+   - "This service uses direct HttpClient; others use typed clients"
+   - "Authorization is done via requirements; some services use policies"
+   - "Events are published via Service Bus; check if your scenario needs async vs direct"
+
+### Step 4 — Verify completeness
+
+Before ending the answer, check:
+
+- [ ] User understands the contract (inputs, outputs, errors)
+- [ ] User sees a real code reference (not invented)
+- [ ] User knows where the code lives (repository, service, file path)
+- [ ] User knows any prerequisites (authentication, configuration, dependencies)
+- [ ] User has enough context to implement or integrate
+
+If uncertainty remains, flag it explicitly: _"I found the authorization pattern but not the exact configuration for service-to-service calls; you may want to check the Startup.cs configuration directly."_
+
+## Reference guides
+
+See `references/` for deeper pattern documentation:
+
+- `api-contracts.md` — Fusion service API contracts and versioning
+- `authorization-patterns.md` — Authentication, authorization requirements, role-based access
+- `validation-patterns.md` — Input validation, error responses, business rules
+- `async-patterns.md` — Events, service bus, domain notifications, eventual consistency
+- `integration-patterns.md` — Cross-service calls, external APIs, webhook handling
+- `cqrs-reference.md` — CQRS handlers, commands, queries, notifications structure
+
+## Assets
+
+- `assets/follow-up-questions.md` — Clarifying questions for ambiguous requests
+- `assets/integration-scenarios.md` — Common integration scenarios and which patterns apply
+
+## Safety & constraints
+
+Never:
+- Describe backend API behavior you cannot verify in retrieved source code
+- Claim a pattern exists when search returns no evidence
+- Invent examples of code that doesn't exist in the repository
+- Suggest modifying a backend service — that's out of scope
+
+Always:
+- Capture and cite the source file path when showing code
+- State explicitly which repository the pattern comes from
+- Note when a pattern exists in one service but not others (services have variation)
+- Offer to escalate to `fusion-services-develop` skill if the user wants to implement changes

--- a/skills/fusion-backend-dev/SKILL.md
+++ b/skills/fusion-backend-dev/SKILL.md
@@ -150,4 +150,4 @@ Always:
 - Capture and cite the source file path when showing code
 - State explicitly which repository the pattern comes from
 - Note when a pattern exists in one service but not others (services have variation)
-- Offer to escalate to `fusion-services-develop` skill if the user wants to implement changes
+- Offer to escalate to `fusion-services-develop` skill (available in the [fusion-core-services](https://github.com/equinor/fusion-core-services) repo) if the user wants to implement changes

--- a/skills/fusion-backend-dev/SKILL.md
+++ b/skills/fusion-backend-dev/SKILL.md
@@ -2,10 +2,10 @@
 name: fusion-backend-dev
 description: 'Guides consumption and understanding of Fusion backend services, APIs, and patterns for frontend/client developers, integrators, and architects. Shows reference implementations, explains architectural decisions, and clarifies contracts. USE FOR: understanding Fusion backend APIs, learning implementation patterns, exploring reference code, choosing the right integration point, and understanding authorization/validation/async patterns. DO NOT USE FOR: modifying backend services, creating new endpoints, database changes, or backend-specific development (use fusion-services-develop or backend service repo instead).'
 license: MIT
-compatibility: Works best with Fusion MCP. Requires mcp_fusion_search_backend_code for reference code discovery. Frontend/client developers should also install fusion-research for deeper architectural context.
+compatibility: Works best with Fusion MCP. Works best with mcp_fusion_search_backend_code for reference code discovery. Frontend/client developers should also install fusion-research for deeper architectural context.
 metadata:
-  version: "0.1.0"
-  status: experimental
+  version: "0.0.0"
+  status: active
   owner: "@equinor/fusion-core"
   skills:
     - fusion-research
@@ -19,7 +19,6 @@ metadata:
   mcp:
     suggested:
       - mcp_fusion_search_backend_code
-      - mcp_fusion_research
 ---
 
 # Fusion Backend Consumption
@@ -136,7 +135,7 @@ See `references/` for deeper pattern documentation:
 ## Assets
 
 - `assets/follow-up-questions.md` — Clarifying questions for ambiguous requests
-- `assets/integration-scenarios.md` — Common integration scenarios and which patterns apply
+- `references/integration-patterns.md` — Common integration scenarios and which patterns apply
 
 ## Safety & constraints
 

--- a/skills/fusion-backend-dev/SKILL.md
+++ b/skills/fusion-backend-dev/SKILL.md
@@ -141,13 +141,14 @@ See `references/` for deeper pattern documentation:
 ## Safety & constraints
 
 Never:
-- Describe backend API behavior you cannot verify in retrieved source code
-- Claim a pattern exists when search returns no evidence
-- Invent examples of code that doesn't exist in the repository
+- Describe real backend API behavior or repository-specific implementation details as fact unless you can verify them in retrieved source code or clearly cited repository documentation
+- Claim a pattern exists in a repository when search returns no evidence
+- Present illustrative pseudo-code, C#, JSON, or payload examples as if they were retrieved source code
 - Suggest modifying a backend service — that's out of scope
 
 Always:
-- Capture and cite the source file path when showing code
+- Clearly label illustrative examples as examples/pseudo-code when they are explanatory rather than retrieved from source
+- Capture and cite repository, file path, and line references when showing real code or summarizing behavior evidenced by MCP search results
 - State explicitly which repository the pattern comes from
 - Note when a pattern exists in one service but not others (services have variation)
 - Offer to escalate to `fusion-services-develop` skill (available in the [fusion-core-services](https://github.com/equinor/fusion-core-services) repo) if the user wants to implement changes

--- a/skills/fusion-backend-dev/SKILL.md
+++ b/skills/fusion-backend-dev/SKILL.md
@@ -9,6 +9,7 @@ metadata:
   owner: "@equinor/fusion-core"
   skills:
     - fusion-research
+    - fusion-code-conventions
   tags:
     - fusion-backend
     - api-consumption

--- a/skills/fusion-backend-dev/assets/follow-up-questions.md
+++ b/skills/fusion-backend-dev/assets/follow-up-questions.md
@@ -1,0 +1,85 @@
+# Follow-Up Questions
+
+Use these when the user's request is ambiguous or missing key context.
+
+## Integration Scenario
+
+**When**: User asks about using a backend service but doesn't specify the context
+
+```
+"I need to call the People API"
+→ Are you building a:
+  - Frontend app that displays person data?
+  - Backend service that needs person information?
+  - External integration consuming Fusion APIs?
+  - Batch/scheduled job syncing data?
+```
+
+**When**: User asks for patterns but doesn't specify scope
+
+```
+"Show me error handling patterns"
+→ Are you:
+  - Building a new backend service and want to see how Fusion does it?
+  - Calling another service and want to handle failures?
+  - Building an external integration?
+  - Something else?
+```
+
+## Scope Clarification
+
+**When**: User mentions an operation without detail
+
+```
+"How do I create a context?"
+→ Are you:
+  - A backend developer adding a new endpoint?
+  - A frontend developer calling a create API?
+  - An architect designing the workflow?
+```
+
+**When**: User asks about data without context
+
+```
+"How is Person data structured?"
+→ Do you need:
+  - The API contract (what fields the API returns)?
+  - The database schema (internal storage)?
+  - How data flows between systems?
+  - Authorization/access rules?
+```
+
+## Technical Constraints
+
+**When**: User asks for implementation without constraints
+
+```
+"How should I cache this data?"
+→ Consider:
+  - How often does data change? (Invalidation frequency)
+  - Is consistency critical? (Real-time vs eventual)
+  - What's your storage? (In-memory, Redis, database)
+  - Scale? (Few calls/day vs thousands/minute)
+```
+
+**When**: User asks about integration without specifying direction
+
+```
+"Integrate with external system"
+→ Direction matters:
+  - Does Fusion call the external system?
+  - Does external system call Fusion?
+  - Both (bidirectional)?
+```
+
+## Example Scenarios
+
+Pick the scenario that matches:
+
+- **Frontend app consuming Fusion APIs**: Use `api-contracts.md`, `authorization-patterns.md`, `validation-patterns.md`
+- **Backend service calling another Fusion service**: Use `integration-patterns.md`, `async-patterns.md`
+- **External system integration**: Use `integration-patterns.md`, `async-patterns.md`, `api-contracts.md`
+- **Learning handler patterns**: Use `cqrs-reference.md`
+- **Understanding real-time updates**: Use `async-patterns.md`
+- **Debugging authorization**: Use `authorization-patterns.md`
+- **Error recovery**: Use `validation-patterns.md`

--- a/skills/fusion-backend-dev/references/api-contracts.md
+++ b/skills/fusion-backend-dev/references/api-contracts.md
@@ -165,19 +165,34 @@ Common patterns include:
 
 ## Pagination
 
-Endpoints supporting large result sets use cursor-based pagination:
+Endpoints supporting large result sets use OData-style offset pagination with `$top` and `$skip`. The standard paged response envelope is:
 
 ```json
 {
-  "data": [ /* items */ ],
-  "pageInfo": {
-    "hasNextPage": true,
-    "nextCursor": "eyJwYWdlIjogMn0="
-  }
+  "totalCount": 245,
+  "count": 50,
+  "@nextPage": "/api/v1/resources?$top=50&$skip=50",
+  "@prevPage": null,
+  "value": [ /* items */ ]
 }
 ```
 
-Query with `?first=50&after={cursor}` to fetch next page.
+| Field | Description |
+| --- | --- |
+| `totalCount` | Total matching items (ignoring paging) |
+| `count` | Items in this page |
+| `@nextPage` | Relative URL for next page (`null` when on last page) |
+| `@prevPage` | Relative URL for previous page (omitted on first page) |
+| `value` | Array of result items |
+
+**Common query parameters**:
+- `$top=50` — page size (max varies by endpoint, e.g. 100 for notifications)
+- `$skip=0` — offset into result set
+- `$filter=field eq 'value'` — OData filter (allowed fields declared per endpoint)
+- `$search=term` — full-text search (where supported)
+- `$orderby=field asc` — sort order (where supported)
+
+> **Note:** Not all endpoints support pagination. Some return the full collection directly as an array. Check the target endpoint's OpenAPI/Swagger spec for the actual response shape and supported query parameters.
 
 ---
 

--- a/skills/fusion-backend-dev/references/api-contracts.md
+++ b/skills/fusion-backend-dev/references/api-contracts.md
@@ -43,7 +43,6 @@ Fusion services return errors as RFC 7807 `ProblemDetails` with Fusion-specific 
 ```
 
 > See [validation-patterns.md](./validation-patterns.md) for the full error format reference, including domain errors, authorization errors, and retry guidance.
-```
 
 ### Authorization Header
 
@@ -74,7 +73,7 @@ The access token is a JWT obtained from Azure AD. Scope required depends on the 
 }
 ```
 
-**Required scope**: `api://fusion-people/.default`
+**Required scope**: `api://{resource-app-id}/.default` (verify the actual resource App ID URI for the People service in your environment)
 
 **Authentication**: Azure AD access token
 
@@ -97,7 +96,7 @@ The access token is a JWT obtained from Azure AD. Scope required depends on the 
 }
 ```
 
-**Required scope**: `api://fusion-org/.default`
+**Required scope**: `api://{resource-app-id}/.default` (verify the actual resource App ID URI for the Org service)
 
 ---
 
@@ -117,7 +116,7 @@ The access token is a JWT obtained from Azure AD. Scope required depends on the 
 }
 ```
 
-**Required scope**: `api://fusion-context/.default`
+**Required scope**: `api://{resource-app-id}/.default` (verify the actual resource App ID URI for the Context service)
 
 ---
 

--- a/skills/fusion-backend-dev/references/api-contracts.md
+++ b/skills/fusion-backend-dev/references/api-contracts.md
@@ -1,0 +1,182 @@
+# API Contracts & Versioning
+
+## Fusion Service API Structure
+
+All Fusion backend services follow a consistent REST API pattern:
+
+### Base Pattern
+
+```
+GET    /api/v{major}/                    # Endpoint root
+POST   /api/v{major}/                    # Resource creation
+PUT    /api/v{major}/{id}                # Resource replacement
+PATCH  /api/v{major}/{id}                # Resource partial update
+DELETE /api/v{major}/{id}                # Resource deletion
+```
+
+### Versioning Strategy
+
+- **Major version**: Incompatible changes (breaking changes to response shape, required fields, semantics)
+- **Minor version** (via header): Non-breaking enhancements (new optional fields, new endpoints, new operations)
+- **Version in URL** (`/api/v3/`): Always required; defines minimum compatibility level
+- **Version in header** (`Api-Version: 3.1`): Optional; enables minor-version selection within a major version
+
+### Error Response Format
+
+All errors return standard format:
+
+```csharp
+{
+  "code": "VALIDATION_FAILED",           // Machine-readable error code
+  "message": "One or more validation errors occurred",  // Human-readable message
+  "details": [                           // Optional: structured error details
+    {
+      "field": "email",
+      "code": "INVALID_FORMAT",
+      "message": "Email format is invalid"
+    }
+  ],
+  "timestamp": "2026-04-17T10:30:00Z"
+}
+```
+
+### Authorization Header
+
+All requests (except health checks) require:
+
+```
+Authorization: Bearer {access_token}
+```
+
+The access token is a JWT obtained from Azure AD. Scope required depends on the endpoint.
+
+---
+
+## Common API Contracts
+
+### People Service
+
+**Endpoint**: `GET /api/v3/persons/{personId}`
+
+**Response** (simplified):
+```json
+{
+  "id": "bbe7b3e5-b1da-4a3f-a0b8-7f7f8f8f8f8f",
+  "name": "John Doe",
+  "email": "john.doe@equinor.com",
+  "roles": ["engineer", "reviewer"],
+  "phone": "+47 40 00 00 00"
+}
+```
+
+**Required scope**: `api://fusion-people/.default`
+
+**Authentication**: Azure AD access token
+
+---
+
+### Org Service
+
+**Endpoint**: `GET /api/v2/org-units/{orgUnitId}`
+
+**Response** (simplified):
+```json
+{
+  "id": "a-uuid",
+  "name": "Engineering",
+  "parentId": "parent-uuid",
+  "children": [
+    { "id": "child-uuid", "name": "Subsystems" }
+  ],
+  "manager": { "id": "person-id", "name": "Jane Smith" }
+}
+```
+
+**Required scope**: `api://fusion-org/.default`
+
+---
+
+### Context Service
+
+**Endpoint**: `GET /api/v1/contexts/{contextId}`
+
+**Response** (simplified):
+```json
+{
+  "id": "ctx-uuid",
+  "title": "Project Alpha",
+  "type": "ProjectDeliveryContext",
+  "externalId": "external-ref",
+  "startDate": "2026-01-01",
+  "endDate": "2027-12-31"
+}
+```
+
+**Required scope**: `api://fusion-context/.default`
+
+---
+
+## Integration Points
+
+### REST API Consumption
+
+Most common for:
+- Frontend applications reading data
+- External integrations (webhooks, periodic sync)
+- Service-to-service calls via typed HTTP clients
+
+### Event Subscription
+
+Available for:
+- Real-time updates (Person promoted, Context created)
+- Async integration with other systems
+- Workflow triggers
+
+See `async-patterns.md` for event details.
+
+---
+
+## Rate Limiting
+
+Most Fusion services implement standard rate limiting:
+
+- **Default**: 1000 requests per minute per caller
+- **Exceeded**: Returns `429 Too Many Requests` with `Retry-After` header
+- **Header**: `X-RateLimit-Remaining` shows remaining quota
+
+---
+
+## Pagination
+
+Endpoints supporting large result sets use cursor-based pagination:
+
+```json
+{
+  "data": [ /* items */ ],
+  "pageInfo": {
+    "hasNextPage": true,
+    "nextCursor": "eyJwYWdlIjogMn0="
+  }
+}
+```
+
+Query with `?first=50&after={cursor}` to fetch next page.
+
+---
+
+## When Contracts Change
+
+### Breaking Changes
+- New required field
+- Removed field
+- Changed field type or semantics
+- New mandatory query parameter
+
+**Action**: New major version `/api/v4/` endpoint, old version remains for compatibility window (usually 2 versions or 6 months)
+
+### Non-Breaking Changes
+- New optional field
+- New optional query parameter
+- New operation/endpoint
+
+**Action**: Increment minor version in header; no URL change required

--- a/skills/fusion-backend-dev/references/api-contracts.md
+++ b/skills/fusion-backend-dev/references/api-contracts.md
@@ -6,20 +6,30 @@ All Fusion backend services follow a consistent REST API pattern:
 
 ### Base Pattern
 
+Routes use absolute paths without a version prefix. API version is supplied via query string or header — not as a URL segment.
+
 ```
-GET    /api/v{major}/                    # Endpoint root
-POST   /api/v{major}/                    # Resource creation
-PUT    /api/v{major}/{id}                # Resource replacement
-PATCH  /api/v{major}/{id}                # Resource partial update
-DELETE /api/v{major}/{id}                # Resource deletion
+GET    /resources                        # List resources
+GET    /resources/{id}                   # Get single resource
+POST   /resources                        # Create resource
+PATCH  /resources/{id}                   # Partial update
+DELETE /resources/{id}                   # Delete resource
 ```
+
+Version negotiation: `?api-version=3.0` (query string) or `api-version: 3.0` (request header).
 
 ### Versioning Strategy
 
+Fusion services use `Asp.Versioning` with a custom `HeaderOrQueryVersionReader`. Version is negotiated via:
+
+- **Query string**: `?api-version=3.0` (preferred)
+- **Request header**: `api-version: 3.0`
+
+`AssumeDefaultVersionWhenUnspecified` is enabled, so unversioned requests receive the default version.
+
+Version levels:
 - **Major version**: Incompatible changes (breaking changes to response shape, required fields, semantics)
-- **Minor version** (via header): Non-breaking enhancements (new optional fields, new endpoints, new operations)
-- **Version in URL** (`/api/v3/`): Always required; defines minimum compatibility level
-- **Version in header** (`Api-Version: 3.1`): Optional; enables minor-version selection within a major version
+- **Minor version**: Non-breaking enhancements (new optional fields, new endpoints)
 
 ### Error Response Format
 
@@ -60,18 +70,23 @@ The access token is a JWT obtained from Azure AD. Scope required depends on the 
 
 ### People Service
 
-**Endpoint**: `GET /api/v3/persons/{personId}`
+**Endpoint**: `GET /persons/{personId}?api-version=3.0`
 
-**Response** (simplified):
+Route attribute: `[HttpGet("/persons/{personId}")]` with `[MapToApiVersion("3.0")]`. Also supports `GET /persons/me`.
+
+**Response** (illustrative — verify exact shape in the service's Swagger/OpenAPI spec):
 ```json
 {
-  "id": "bbe7b3e5-b1da-4a3f-a0b8-7f7f8f8f8f8f",
+  "azureUniqueId": "bbe7b3e5-b1da-4a3f-a0b8-7f7f8f8f8f8f",
   "name": "John Doe",
-  "email": "john.doe@equinor.com",
-  "roles": ["engineer", "reviewer"],
-  "phone": "+47 40 00 00 00"
+  "mail": "john.doe@equinor.com",
+  "accountType": "Employee",
+  "department": "Engineering",
+  "fullDepartment": "TDI PRD ENG TSE"
 }
 ```
+
+Supports OData expansion: `?$expand=roles,positions,contracts,manager` (v3) and additionally `companies` (v4).
 
 **Required scope**:
 - Delegated (user token): `api://{resource-app-id}/user_impersonation`
@@ -83,44 +98,48 @@ Verify the actual resource App ID URI for the People service in your environment
 
 ---
 
-### Org Service
+### LineOrg Service
 
-**Endpoint**: `GET /api/v2/org-units/{orgUnitId}`
+**Endpoint**: `GET /org-units/{orgUnitId}`
 
-**Response** (simplified):
+The Org service handles projects, positions, and contracts (`/projects/{id}/positions/...`). The org-unit hierarchy (departments, management chain) is served by the **LineOrg** service.
+
+**Response** (illustrative — verify exact shape in the service's Swagger/OpenAPI spec):
 ```json
 {
-  "id": "a-uuid",
+  "sapId": "51234",
   "name": "Engineering",
-  "parentId": "parent-uuid",
-  "children": [
-    { "id": "child-uuid", "name": "Subsystems" }
-  ],
-  "manager": { "id": "person-id", "name": "Jane Smith" }
+  "fullDepartment": "TDI PRD ENG TSE",
+  "shortName": "TSE",
+  "level": 5,
+  "children": []
 }
 ```
+
+Supports OData expansion: `?$expand=children,management`.
 
 **Required scope**:
 - Delegated: `api://{resource-app-id}/user_impersonation`
 - App-only: `api://{resource-app-id}/.default`
 
-Verify the actual resource App ID URI for the Org service in your environment.
+Verify the actual resource App ID URI for the LineOrg service in your environment.
 
 ---
 
 ### Context Service
 
-**Endpoint**: `GET /api/v1/contexts/{contextId}`
+**Endpoint**: `GET /contexts/{id}?api-version=1.0`
 
-**Response** (simplified):
+Route attribute: `[HttpGet("/contexts/{id}")]` with `[ApiVersion("1.0")]`. Also supports `GET /contexts` with OData filter/search and `GET /contexts/{id}/relations`.
+
+**Response** (illustrative — verify exact shape in the service's Swagger/OpenAPI spec):
 ```json
 {
   "id": "ctx-uuid",
   "title": "Project Alpha",
-  "type": "ProjectDeliveryContext",
+  "type": { "id": "ProjectMaster", "isCustom": false },
   "externalId": "external-ref",
-  "startDate": "2026-01-01",
-  "endDate": "2027-12-31"
+  "isActive": true
 }
 ```
 
@@ -171,7 +190,7 @@ Endpoints supporting large result sets use OData-style offset pagination with `$
 {
   "totalCount": 245,
   "count": 50,
-  "@nextPage": "/api/v1/resources?$top=50&$skip=50",
+  "@nextPage": "/resources?$top=50&$skip=50&api-version=1.0",
   "@prevPage": null,
   "value": [ /* items */ ]
 }
@@ -204,7 +223,7 @@ Endpoints supporting large result sets use OData-style offset pagination with `$
 - Changed field type or semantics
 - New mandatory query parameter
 
-**Action**: New major version `/api/v4/` endpoint, old version remains for compatibility window (usually 2 versions or 6 months)
+**Action**: New major version (e.g., `api-version=4.0`), old version remains for compatibility window (usually 2 versions or 6 months)
 
 ### Non-Breaking Changes
 - New optional field

--- a/skills/fusion-backend-dev/references/api-contracts.md
+++ b/skills/fusion-backend-dev/references/api-contracts.md
@@ -23,9 +23,9 @@ DELETE /api/v{major}/{id}                # Resource deletion
 
 ### Error Response Format
 
-All errors return standard format:
+All errors return a standard JSON shape:
 
-```csharp
+```json
 {
   "code": "VALIDATION_FAILED",           // Machine-readable error code
   "message": "One or more validation errors occurred",  // Human-readable message
@@ -138,11 +138,12 @@ See `async-patterns.md` for event details.
 
 ## Rate Limiting
 
-Most Fusion services implement standard rate limiting:
+Fusion services may apply rate limiting, but quotas, headers, and retry behavior can vary by service and environment.
 
-- **Default**: 1000 requests per minute per caller
-- **Exceeded**: Returns `429 Too Many Requests` with `Retry-After` header
-- **Header**: `X-RateLimit-Remaining` shows remaining quota
+Common patterns include:
+- **Exceeded**: `429 Too Many Requests`, sometimes with a `Retry-After` header
+- **Headers**: Some services or gateways may expose headers such as `X-RateLimit-Remaining`
+- **Quotas**: Request limits are service-specific; verify exact limits in the target API/OpenAPI documentation
 
 ---
 

--- a/skills/fusion-backend-dev/references/api-contracts.md
+++ b/skills/fusion-backend-dev/references/api-contracts.md
@@ -23,21 +23,26 @@ DELETE /api/v{major}/{id}                # Resource deletion
 
 ### Error Response Format
 
-All errors return a standard JSON shape:
+Fusion services return errors as RFC 7807 `ProblemDetails` with Fusion-specific extensions:
 
 ```json
 {
-  "code": "VALIDATION_FAILED",           // Machine-readable error code
-  "message": "One or more validation errors occurred",  // Human-readable message
-  "details": [                           // Optional: structured error details
-    {
-      "field": "email",
-      "code": "INVALID_FORMAT",
-      "message": "Email format is invalid"
-    }
-  ],
+  "type": "https://tools.ietf.org/html/rfc7231#section-6.5.1",
+  "title": "One or more validation errors occurred.",
+  "status": 400,
+  "error": {
+    "code": "ModelValidationError",
+    "message": "Model contained 1 errors"
+  },
+  "errors": {
+    "email": ["Email format is invalid"]
+  },
+  "traceId": "...",
   "timestamp": "2026-04-17T10:30:00Z"
 }
+```
+
+> See [validation-patterns.md](./validation-patterns.md) for the full error format reference, including domain errors, authorization errors, and retry guidance.
 ```
 
 ### Authorization Header

--- a/skills/fusion-backend-dev/references/api-contracts.md
+++ b/skills/fusion-backend-dev/references/api-contracts.md
@@ -223,7 +223,7 @@ Endpoints supporting large result sets use OData-style offset pagination with `$
 - Changed field type or semantics
 - New mandatory query parameter
 
-**Action**: New major version (e.g., `api-version=4.0`), old version remains for compatibility window (usually 2 versions or 6 months)
+**Action**: New major version (e.g., `api-version=4.0`); keep the old version available according to the target service's documented compatibility or deprecation policy
 
 ### Non-Breaking Changes
 - New optional field

--- a/skills/fusion-backend-dev/references/api-contracts.md
+++ b/skills/fusion-backend-dev/references/api-contracts.md
@@ -32,7 +32,7 @@ Fusion services return errors as RFC 7807 `ProblemDetails` with Fusion-specific 
   "status": 400,
   "error": {
     "code": "ModelValidationError",
-    "message": "Model contained 1 errors"
+    "message": "Model contained 1 error"
   },
   "errors": {
     "email": ["Email format is invalid"]
@@ -73,7 +73,11 @@ The access token is a JWT obtained from Azure AD. Scope required depends on the 
 }
 ```
 
-**Required scope**: `api://{resource-app-id}/.default` (verify the actual resource App ID URI for the People service in your environment)
+**Required scope**:
+- Delegated (user token): `api://{resource-app-id}/user_impersonation`
+- App-only (client credentials): `api://{resource-app-id}/.default`
+
+Verify the actual resource App ID URI for the People service in your environment.
 
 **Authentication**: Azure AD access token
 
@@ -96,7 +100,11 @@ The access token is a JWT obtained from Azure AD. Scope required depends on the 
 }
 ```
 
-**Required scope**: `api://{resource-app-id}/.default` (verify the actual resource App ID URI for the Org service)
+**Required scope**:
+- Delegated: `api://{resource-app-id}/user_impersonation`
+- App-only: `api://{resource-app-id}/.default`
+
+Verify the actual resource App ID URI for the Org service in your environment.
 
 ---
 
@@ -116,7 +124,11 @@ The access token is a JWT obtained from Azure AD. Scope required depends on the 
 }
 ```
 
-**Required scope**: `api://{resource-app-id}/.default` (verify the actual resource App ID URI for the Context service)
+**Required scope**:
+- Delegated: `api://{resource-app-id}/user_impersonation`
+- App-only: `api://{resource-app-id}/.default`
+
+Verify the actual resource App ID URI for the Context service in your environment.
 
 ---
 

--- a/skills/fusion-backend-dev/references/async-patterns.md
+++ b/skills/fusion-backend-dev/references/async-patterns.md
@@ -86,35 +86,42 @@ Several Fusion services expose subscription endpoints that create a Service Bus 
 
 ### Connecting with the SAS Token
 
-Use the returned connection details to create a Service Bus client:
+Use the returned connection details to create a Service Bus client.
+The `endpoint` is an `sb://` URI — extract the host for `ServiceBusClient`:
 
 ```csharp
+// Parse the sb:// endpoint to get the host name
+var endpointUri = new Uri(connection.Endpoint);
+
 var client = new ServiceBusClient(
-    endpoint.Host,
+    endpointUri.Host,
     new AzureSasCredential(connection.Token.TokenValue));
 
-var processor = client.CreateProcessor(connection.Path, new ServiceBusProcessorOptions
-{
-    MaxConcurrentCalls = 1
-});
+// connection.Path is the full subscription path: "{topic}/subscriptions/{name}"
+var processor = client.CreateProcessor(
+    connection.Path,
+    new ServiceBusProcessorOptions { MaxConcurrentCalls = 1 });
 
 processor.ProcessMessageAsync += async (args) =>
 {
     string body = args.Message.Body.ToString();
     // Body is a CloudEvent v1.0 JSON; deserialize accordingly
-    CloudEventV1 cloudEvent = JsonConvert.DeserializeObject<CloudEventV1>(body);
+    var cloudEvent = JsonConvert.DeserializeObject<CloudEventV1>(body);
     // Process the event...
 };
 
 processor.ProcessErrorAsync += async (args) =>
 {
-    // Handle errors; SAS token expiry appears as UnauthorizedAccessException
+    if (args.Exception is UnauthorizedAccessException)
+    {
+        // SAS token expired — renew by calling the subscription endpoint again
+    }
 };
 
 await processor.StartProcessingAsync();
 ```
 
-> **Token renewal:** SAS tokens expire. When `UnauthorizedAccessException` occurs, call the subscription endpoint again to get a fresh token and reconnect.
+> **Token renewal:** SAS tokens expire. When `UnauthorizedAccessException` occurs, stop the processor, call the subscription endpoint again to get a fresh token, and reconnect with a new client.
 
 ### Filtering Events
 

--- a/skills/fusion-backend-dev/references/async-patterns.md
+++ b/skills/fusion-backend-dev/references/async-patterns.md
@@ -1,0 +1,226 @@
+# Async & Event Patterns
+
+## Event Publishing
+
+Fusion services publish events to Service Bus when important things happen:
+
+### Event Types
+
+| Event | Service | Scenario |
+| --- | --- | --- |
+| `PersonUpdated` | People | Person name, email, or roles change |
+| `PersonDeleted` | People | Person account archived |
+| `ContextCreated` | Context | New project/initiative context |
+| `ContextModified` | Context | Context properties changed |
+| `PositionAssigned` | Context | New position holder assigned |
+| `PositionUnassigned` | Context | Position holder removed |
+| `ApprovalRequested` | Approvals | New approval needed |
+| `ApprovalCompleted` | Approvals | Approval given/rejected |
+
+### Event Format
+
+```json
+{
+  "eventType": "PositionAssigned",
+  "eventId": "uuid",
+  "timestamp": "2026-04-17T10:30:00Z",
+  "source": "fusion-context-service",
+  "data": {
+    "contextId": "ctx-uuid",
+    "positionId": "pos-uuid",
+    "personId": "person-uuid",
+    "title": "Project Manager",
+    "startDate": "2026-04-17",
+    "endDate": "2027-04-17"
+  },
+  "version": "1.0"
+}
+```
+
+---
+
+## Event Subscription
+
+### Azure Service Bus Subscription
+
+To receive events:
+
+1. **Get Service Bus endpoint**: Provided in project setup
+2. **Create subscription**: Subscribe to the event topic (e.g., `fusion.context-events`)
+3. **Implement receiver**: Handle incoming messages
+
+**Example subscriptions**:
+- `fusion.context-events` → all context events
+- `fusion.people-events` → all person events
+
+### Filtering Events
+
+Most subscriptions support filters:
+
+```
+eventType = 'PositionAssigned'
+source = 'fusion-context-service'
+```
+
+### Message Format on Bus
+
+```
+{
+  "body": { /* event JSON */ },
+  "properties": {
+    "eventType": "PositionAssigned",
+    "timestamp": "2026-04-17T10:30:00Z",
+    "contentType": "application/json"
+  }
+}
+```
+
+---
+
+## Common Event Patterns
+
+### Pattern: Real-Time Sync
+
+When another system needs to stay in sync:
+
+```
+1. User does action in Fusion
+2. Fusion publishes event
+3. External system receives event
+4. External system updates its local copy
+```
+
+**Use case**: Dashboard showing current org chart, active positions
+
+**Challenge**: Initial state. Solution: Fetch full snapshot on startup, then subscribe to incremental updates.
+
+### Pattern: Eventual Consistency
+
+When operations span multiple services:
+
+```
+1. User creates context → Context service publishes ContextCreated
+2. Approvals service receives → Creates default approvals
+3. Reporting service receives → Adds to reporting index
+4. Notifications service receives → Sends "New project" message
+```
+
+**Key**: All listeners are independent; failure in one doesn't block the others.
+
+### Pattern: Webhook Delivery
+
+When external system needs webhooks (not pub/sub):
+
+```
+1. External system registers webhook URL with Fusion
+2. Event occurs in Fusion
+3. Fusion makes HTTP POST to webhook URL
+4. External system processes the request
+```
+
+**Contract**: 
+```
+POST {webhook_url}
+Content-Type: application/json
+X-Fusion-Event-Type: PositionAssigned
+X-Fusion-Signature: hmac-sha256
+
+{ /* event body */ }
+```
+
+---
+
+## Handling Events
+
+### Idempotent Processing
+
+Events can be delivered multiple times. Your handler must be idempotent:
+
+```csharp
+// ❌ NOT idempotent:
+public void Handle(PositionAssigned @event)
+{
+  var position = _db.Positions.Add(@event.Data);
+  _db.SaveChanges();
+}
+
+// ✅ Idempotent:
+public void Handle(PositionAssigned @event)
+{
+  var existing = _db.Positions.Find(@event.Data.PositionId);
+  if (existing == null)
+  {
+    _db.Positions.Add(@event.Data);
+    _db.SaveChanges();
+  }
+  // If already processed, no-op
+}
+```
+
+### Error Handling
+
+What if processing fails?
+
+```csharp
+try
+{
+  ProcessEvent(@event);
+  AcknowledgeMessage(message);  // Tell bus we succeeded
+}
+catch (RecoverableException ex)
+{
+  // Retry later (service bus will redeliver)
+  // Don't acknowledge; message stays on queue
+}
+catch (PoisonMessage ex)
+{
+  // This event is bad; move to dead-letter queue
+  MoveToDlq(message);
+}
+```
+
+### Ordering Guarantees
+
+Service Bus provides **per-partition ordering**:
+
+- Events for same context arrive in order
+- Events for different contexts may be out of order
+- Don't assume global ordering
+
+**If you need strict ordering**: Use partition key (`contextId`) to route related events to same partition.
+
+---
+
+## Async APIs (Polling)
+
+Some long-running operations use polling:
+
+```
+1. Start operation → Returns operation ID
+2. Poll status endpoint with operation ID
+3. Operation completes → Returns result
+```
+
+**Example**:
+```
+POST /api/v1/contexts → 202 Accepted
+{ "operationId": "op-uuid" }
+
+GET /api/v1/contexts/op-uuid → 
+{ "status": "InProgress", "progress": 45 }
+
+// Later...
+GET /api/v1/contexts/op-uuid →
+{ "status": "Completed", "contextId": "ctx-uuid" }
+```
+
+---
+
+## When to Use Each Pattern
+
+| Pattern | Use Case | Pro | Con |
+| --- | --- | --- | --- |
+| **Event Subscription** | Real-time sync, multi-system orchestration | Decoupled, fire-and-forget, scales | Complex setup, eventual consistency |
+| **Webhook** | External system notification | Simple for external partners, HTTP standard | Requires public endpoint, delivery challenges |
+| **Polling** | Frontend UX (show progress), long operations | Simple client code, user control | Chatty, can be slow |
+| **Direct API Call** | Immediate result needed, tight coupling acceptable | Simple, immediate feedback | Tightly coupled, not resilient to changes |

--- a/skills/fusion-backend-dev/references/async-patterns.md
+++ b/skills/fusion-backend-dev/references/async-patterns.md
@@ -140,14 +140,14 @@ Events can be delivered multiple times. Your handler must be idempotent:
 // ❌ NOT idempotent:
 public void Handle(PositionAssigned @event)
 {
-  var position = _db.Positions.Add(@event.Data);
+  DbPosition position = _db.Positions.Add(@event.Data);
   _db.SaveChanges();
 }
 
 // ✅ Idempotent:
 public void Handle(PositionAssigned @event)
 {
-  var existing = _db.Positions.Find(@event.Data.PositionId);
+  DbPosition? existing = _db.Positions.Find(@event.Data.PositionId);
   if (existing == null)
   {
     _db.Positions.Add(@event.Data);

--- a/skills/fusion-backend-dev/references/async-patterns.md
+++ b/skills/fusion-backend-dev/references/async-patterns.md
@@ -97,12 +97,28 @@ var client = new ServiceBusClient(
     endpointUri.Host,
     new AzureSasCredential(connection.Token.TokenValue));
 
-// connection.Path is the full subscription path: "{topic}/Subscriptions/{name}"
+// connection.Path is the full subscription path: "{topic}/subscriptions/{name}"
 // Use the topic + subscription overload for ServiceBusProcessor
-var pathSegments = connection.Path.Split("/Subscriptions/");
+const string subscriptionSegment = "/subscriptions/";
+var subscriptionIndex = connection.Path.IndexOf(subscriptionSegment, StringComparison.OrdinalIgnoreCase);
+if (subscriptionIndex < 0)
+{
+    throw new InvalidOperationException(
+        $"Unexpected Service Bus subscription path format: '{connection.Path}'.");
+}
+
+var topicName = connection.Path[..subscriptionIndex];
+var subscriptionName = connection.Path[(subscriptionIndex + subscriptionSegment.Length)..];
+
+if (string.IsNullOrWhiteSpace(topicName) || string.IsNullOrWhiteSpace(subscriptionName))
+{
+    throw new InvalidOperationException(
+        $"Unexpected Service Bus subscription path format: '{connection.Path}'.");
+}
+
 var processor = client.CreateProcessor(
-    pathSegments[0],  // topic name
-    pathSegments[1],  // subscription name
+    topicName,
+    subscriptionName,
     new ServiceBusProcessorOptions { MaxConcurrentCalls = 1 });
 
 processor.ProcessMessageAsync += async (args) =>

--- a/skills/fusion-backend-dev/references/async-patterns.md
+++ b/skills/fusion-backend-dev/references/async-patterns.md
@@ -140,7 +140,13 @@ Events can be delivered multiple times. Your handler must be idempotent:
 // ❌ NOT idempotent:
 public void Handle(PositionAssigned @event)
 {
-  DbPosition position = _db.Positions.Add(@event.Data);
+  DbPosition position = new DbPosition
+  {
+    PositionId = @event.Data.PositionId,
+    PersonId = @event.Data.PersonId,
+    Title = @event.Data.Title
+  };
+  _db.Positions.Add(position);
   _db.SaveChanges();
 }
 
@@ -150,7 +156,13 @@ public void Handle(PositionAssigned @event)
   DbPosition? existing = _db.Positions.Find(@event.Data.PositionId);
   if (existing == null)
   {
-    _db.Positions.Add(@event.Data);
+    DbPosition position = new DbPosition
+    {
+      PositionId = @event.Data.PositionId,
+      PersonId = @event.Data.PersonId,
+      Title = @event.Data.Title
+    };
+    _db.Positions.Add(position);
     _db.SaveChanges();
   }
   // If already processed, no-op

--- a/skills/fusion-backend-dev/references/async-patterns.md
+++ b/skills/fusion-backend-dev/references/async-patterns.md
@@ -97,9 +97,12 @@ var client = new ServiceBusClient(
     endpointUri.Host,
     new AzureSasCredential(connection.Token.TokenValue));
 
-// connection.Path is the full subscription path: "{topic}/subscriptions/{name}"
+// connection.Path is the full subscription path: "{topic}/Subscriptions/{name}"
+// Use the topic + subscription overload for ServiceBusProcessor
+var pathSegments = connection.Path.Split("/Subscriptions/");
 var processor = client.CreateProcessor(
-    connection.Path,
+    pathSegments[0],  // topic name
+    pathSegments[1],  // subscription name
     new ServiceBusProcessorOptions { MaxConcurrentCalls = 1 });
 
 processor.ProcessMessageAsync += async (args) =>

--- a/skills/fusion-backend-dev/references/async-patterns.md
+++ b/skills/fusion-backend-dev/references/async-patterns.md
@@ -181,14 +181,15 @@ catch (PoisonMessage ex)
 
 ### Ordering Guarantees
 
-Service Bus provides **per-partition ordering**:
+Don't assume messages arrive in order.
 
-- Events for same context arrive in order
-- Events for different contexts may be out of order
+- Events for the same context may still be delivered out of order
+- Events for different contexts may be interleaved or out of order
 - Don't assume global ordering
 
-**If you need strict ordering**: Use partition key (`contextId`) to route related events to same partition.
+**If you need strict ordering**: Use an explicit ordering strategy such as Service Bus Sessions (for example, `sessionId = contextId`) so related events are processed FIFO within that session.
 
+**Tradeoffs**: Sessions require session-aware consumers and can reduce parallelism for events that share the same session.
 ---
 
 ## Async APIs (Polling)

--- a/skills/fusion-backend-dev/references/async-patterns.md
+++ b/skills/fusion-backend-dev/references/async-patterns.md
@@ -282,15 +282,18 @@ Some long-running operations use polling:
 
 **Example**:
 ```
-POST /api/v1/contexts → 202 Accepted
+POST /api/contexts?api-version=1.0 → 202 Accepted
 { "operationId": "op-uuid" }
 
-GET /api/v1/contexts/op-uuid → 
+GET /api/contexts/op-uuid?api-version=1.0 →
 { "status": "InProgress", "progress": 45 }
 
 // Later...
-GET /api/v1/contexts/op-uuid →
+GET /api/contexts/op-uuid?api-version=1.0 →
 { "status": "Completed", "contextId": "ctx-uuid" }
+
+// Alternatively, send the version in a header:
+// api-version: 1.0
 ```
 
 ---

--- a/skills/fusion-backend-dev/references/async-patterns.md
+++ b/skills/fusion-backend-dev/references/async-patterns.md
@@ -2,78 +2,142 @@
 
 ## Event Publishing
 
-Fusion services publish events to Service Bus when important things happen:
+Fusion services publish events to Azure Service Bus topics using `IEventNotificationClient`. Events follow the [CloudEvents v1.0](https://github.com/cloudevents/spec/blob/v1.0/spec.md) specification.
 
-### Event Types
+### Event Type Categories
 
-| Event | Service | Scenario |
-| --- | --- | --- |
-| `PersonUpdated` | People | Person name, email, or roles change |
-| `PersonDeleted` | People | Person account archived |
-| `ContextCreated` | Context | New project/initiative context |
-| `ContextModified` | Context | Context properties changed |
-| `PositionAssigned` | Context | New position holder assigned |
-| `PositionUnassigned` | Context | Position holder removed |
-| `ApprovalRequested` | Approvals | New approval needed |
-| `ApprovalCompleted` | Approvals | Approval given/rejected |
+Event types use a dotted naming convention: `com.equinor.fusion.{domain}.{type}`.
 
-### Event Format
+| Category | Type name | Service | Sub-types (in payload) |
+| --- | --- | --- | --- |
+| People | `com.equinor.fusion.people.profile` | People | `ProfileUpdated`, `UserRemoved` |
+| People | `com.equinor.fusion.people.security` | People | `RolesUpdated` |
+| Context | `com.equinor.fusion.context.context` | Context | `Created`, `Modified`, `Deleted` |
+| Context | `com.equinor.fusion.context.relation` | Context | Relation changes |
+| Org | `com.equinor.fusion.org.position` | Org | `PersonAssigned`, `PersonUnassigned`, `PositionCreated`, `PositionUpdated`, `PositionRemoved` |
+| Org | `com.equinor.fusion.org.project` | Org | `ProjectCreated`, `ProjectUpdated`, `ProjectRemoved` |
+| Org | `com.equinor.fusion.org.contract` | Org | `ContractCreated`, `ContractUpdated`, `ContractRemoved` |
+
+### Event Format (CloudEvents v1.0)
 
 ```json
 {
-  "eventType": "PositionAssigned",
-  "eventId": "uuid",
-  "timestamp": "2026-04-17T10:30:00Z",
+  "specversion": "1.0",
+  "id": "{event-id}",
   "source": "fusion-context-service",
-  "data": {
-    "contextId": "ctx-uuid",
-    "positionId": "pos-uuid",
-    "personId": "person-uuid",
-    "title": "Project Manager",
-    "startDate": "2026-04-17",
-    "endDate": "2027-04-17"
-  },
-  "version": "1.0"
+  "type": "com.equinor.fusion.context.context",
+  "time": "2026-04-17T10:30:00Z",
+  "datacontenttype": "application/json",
+  "fusionCategory": "optional-category",
+  "data": "{ /* JSON-serialized payload string */ }"
 }
 ```
+
+> **Note:** The `data` field is a JSON-serialized string, not a nested object. Deserialize it separately to access the typed payload.
 
 ---
 
 ## Event Subscription
 
-### Azure Service Bus Subscription
+### Subscription API Pattern
 
-To receive events:
+Several Fusion services expose subscription endpoints that create a Service Bus subscription and return connection details with a SAS token. Only application users (service principals) can subscribe.
 
-1. **Get Service Bus endpoint**: Provided in project setup
-2. **Create subscription**: Subscribe to the event topic (e.g., `fusion.context-events`)
-3. **Implement receiver**: Handle incoming messages
+**Known subscription endpoints:**
 
-**Example subscriptions**:
-- `fusion.context-events` → all context events
-- `fusion.people-events` → all person events
+| Service | Endpoint | Topic |
+| --- | --- | --- |
+| Context | `PUT /subscriptions/contexts` | `context-sub` |
+| ContractPersonnel | `PUT /subscriptions/contracts` | `contractpersonnel-sub` |
+| FusionTasks | `PUT /subscriptions/fusiontasks` | `fusiontask-sub` |
+| Roles V2 | `PUT /subscriptions/roles-v2` | `role-v2-sub` |
 
-### Filtering Events
-
-Most subscriptions support filters:
-
-```
-eventType = 'PositionAssigned'
-source = 'fusion-context-service'
-```
-
-### Message Format on Bus
-
-```
+**Request:**
+```json
 {
-  "body": { /* event JSON */ },
-  "properties": {
-    "eventType": "PositionAssigned",
-    "timestamp": "2026-04-17T10:30:00Z",
-    "contentType": "application/json"
+  "id": "optional-guid",
+  "identifier": "my-app-name",
+  "type": "Persistent",
+  "typeFilter": ["com.equinor.fusion.org.position"]
+}
+```
+
+- `type`: `"Persistent"` (auto-deletes after 14 days idle) or `"Transient"` (auto-deletes after 5 minutes idle)
+- `typeFilter`: Optional array of event type names for SQL filter on the `type` message property
+- `identifier`: Your application name; used to generate a recognizable subscription name
+
+**Response:**
+```json
+{
+  "id": "subscription-guid",
+  "handlerName": "context-sub",
+  "connection": {
+    "endpoint": "sb://namespace.servicebus.windows.net",
+    "path": "topic/subscriptions/subscription-name",
+    "token": {
+      "audience": "https://namespace.servicebus.windows.net/path",
+      "tokenValue": "SharedAccessSignature sr=...&sig=...&se=...&skn=SubscribersKey",
+      "tokenType": "servicebus.windows.net:sastoken",
+      "expiresAtUtc": "2026-04-17T12:30:00Z"
+    }
   }
 }
 ```
+
+### Connecting with the SAS Token
+
+Use the returned connection details to create a Service Bus client:
+
+```csharp
+var client = new ServiceBusClient(
+    endpoint.Host,
+    new AzureSasCredential(connection.Token.TokenValue));
+
+var processor = client.CreateProcessor(connection.Path, new ServiceBusProcessorOptions
+{
+    MaxConcurrentCalls = 1
+});
+
+processor.ProcessMessageAsync += async (args) =>
+{
+    string body = args.Message.Body.ToString();
+    // Body is a CloudEvent v1.0 JSON; deserialize accordingly
+    CloudEventV1 cloudEvent = JsonConvert.DeserializeObject<CloudEventV1>(body);
+    // Process the event...
+};
+
+processor.ProcessErrorAsync += async (args) =>
+{
+    // Handle errors; SAS token expiry appears as UnauthorizedAccessException
+};
+
+await processor.StartProcessingAsync();
+```
+
+> **Token renewal:** SAS tokens expire. When `UnauthorizedAccessException` occurs, call the subscription endpoint again to get a fresh token and reconnect.
+
+### Filtering Events
+
+Subscriptions support SQL filters on Service Bus message properties:
+
+```
+type = 'com.equinor.fusion.org.position'
+app = 'my-app-id'
+```
+
+These filters are set via `typeFilter` in the subscription request or managed by the service when creating the subscription.
+
+### Service Bus Message Properties
+
+Messages on the bus carry these `ApplicationProperties` (available for filtering):
+
+| Property | Description |
+| --- | --- |
+| `type` | Event type name (e.g. `com.equinor.fusion.org.position`) |
+| `app` | App context identifier |
+| `origin` | Event origin |
+| `category` | Event category |
+| `batch-id` | Batch identifier (when events are sent as a batch) |
 
 ---
 
@@ -109,24 +173,16 @@ When operations span multiple services:
 
 ### Pattern: Webhook Delivery
 
-When external system needs webhooks (not pub/sub):
+When an external system needs event notifications via HTTP callbacks:
 
 ```
-1. External system registers webhook URL with Fusion
-2. Event occurs in Fusion
-3. Fusion makes HTTP POST to webhook URL
-4. External system processes the request
+1. External system registers webhook URL (via the provider's webhook API)
+2. Event occurs in the source system
+3. Source system makes HTTP POST to the registered callback URL
+4. Receiver validates signature and processes the event
 ```
 
-**Contract**: 
-```
-POST {webhook_url}
-Content-Type: application/json
-X-Fusion-Event-Type: PositionAssigned
-X-Fusion-Signature: hmac-sha256
-
-{ /* event body */ }
-```
+> **Note:** Webhook header names, signature formats, and registration APIs vary by provider. Always check the specific provider's documentation for the exact contract. See [integration-patterns.md](./integration-patterns.md) for an illustrative signature validation pattern.
 
 ---
 

--- a/skills/fusion-backend-dev/references/authorization-patterns.md
+++ b/skills/fusion-backend-dev/references/authorization-patterns.md
@@ -1,0 +1,170 @@
+# Authorization Patterns
+
+## Request Authentication
+
+All Fusion services require an Azure AD access token in the Authorization header:
+
+```
+Authorization: Bearer {jwt_token}
+```
+
+The token is obtained from Azure AD using the Fusion app client ID:
+- **Client ID**: `0ec6e8f2-d309-4316-90e6-1d05628b5f07`
+- **Authority**: `https://login.microsoftonline.com/`
+- **Scope format**: `api://{service-id}/.default`
+
+### Example Scopes
+
+| Service | Scope |
+| --- | --- |
+| People | `api://0ec6e8f2-d309-4316-90e6-1d05628b5f07/people` |
+| Org | `api://0ec6e8f2-d309-4316-90e6-1d05628b5f07/org` |
+| Context | `api://0ec6e8f2-d309-4316-90e6-1d05628b5f07/context` |
+
+---
+
+## Authorization Requirements
+
+Fusion services use ASP.NET Core authorization requirements. Common patterns:
+
+### Requirement-Based Authorization
+
+```csharp
+// Backend service defines a requirement
+public class MustBeContextManagerRequirement : IAuthorizationRequirement
+{
+    public string ContextId { get; set; }
+}
+
+// Frontend passes the requirement check implicitly via:
+// 1. User identity (roles, claims)
+// 2. Resource ownership (context manager, project lead, etc.)
+```
+
+**What this means for consumers**:
+- Your Azure AD identity must include the required role/claim
+- Or you must be explicitly listed as responsible (context manager, position holder)
+- If denied: `403 Forbidden`
+
+### Common Requirements
+
+| Scenario | Requirement | How to satisfy |
+| --- | --- | --- |
+| Read Context | `CanReadContext` | Any authenticated user with `api://fusion-context/.default` scope |
+| Modify Context | `IsContextManager` | Must have "ContextManager" role in that context OR hold a position in it |
+| Delete Position | `CanDeletePosition` | Must be HR admin OR context manager where position exists |
+| View Person | `CanViewPerson` | Any authenticated user with `api://fusion-people/.default` scope |
+
+---
+
+## Role-Based Access Control (RBAC)
+
+Fusion services assign roles per user per resource. Example: roles in a context:
+
+```json
+{
+  "contextId": "abc-def",
+  "userId": "person-123",
+  "roles": ["ContextManager", "Approver", "Contributor"]
+}
+```
+
+**How roles affect API behavior**:
+- **ContextManager**: Can create positions, assign responsibilities, modify context properties
+- **Approver**: Can approve requests within the context
+- **Contributor**: Can edit owned resources; read access to context
+- **Viewer**: Read-only access to context and positions
+
+Check role claims in your token to understand what you can do.
+
+---
+
+## Common Authorization Errors
+
+### 401 Unauthorized
+
+**Cause**: Missing or invalid token
+
+**Fix**:
+- Confirm token is in `Authorization: Bearer {token}` header
+- Verify token is not expired
+- Verify token was requested with correct scope
+
+### 403 Forbidden
+
+**Cause**: Token is valid but user doesn't have required role/permission
+
+**Fix**:
+- Confirm user has required role in this context/service
+- Ask context manager to assign role if needed
+- Check if user is responsible (position holder, manager, etc.)
+
+### 400 Bad Request with authorization detail
+
+**Cause**: Authorization requirement validation failed
+
+**Response example**:
+```json
+{
+  "code": "REQUIREMENT_NOT_MET",
+  "message": "User must be context manager",
+  "details": { "requirement": "IsContextManager" }
+}
+```
+
+**Fix**: Escalate to someone with the required role, or ask your manager to add your responsibility
+
+---
+
+## Service-to-Service Authentication
+
+When one Fusion service calls another (internal only):
+
+1. Service acquires a token for the **service principal** (not user)
+2. Token is requested with service's own scope
+3. Called service validates the caller's service identity
+
+**This is internal only** — as a client, you don't implement this directly. But you should know:
+- Fusion services can communicate securely
+- Cross-service calls are authenticated and authorized
+- If a service can't reach another, it's usually a service principal permission issue (not your problem as a consumer)
+
+---
+
+## API Key Authentication (Special Cases)
+
+Some non-user integrations accept API keys instead of Azure AD tokens:
+
+```
+Authorization: ApiKey {api-key}
+```
+
+**When**: Limited external integrations, batch operations, webhook receivers
+
+**How to get**: Request from service owner; usually provided in project setup
+
+---
+
+## Checking Your Permissions
+
+Before calling an endpoint, understand what you can do:
+
+1. **Get your token**: Request from Azure AD with `api://{service}/.default` scope
+2. **Decode the token**: Use jwt.ms or similar to see your roles/claims
+3. **Check the endpoint docs**: Look for "Required role" or "Requirement" field
+4. **Verify you have that role**: If not, ask your manager or context manager to assign it
+
+### Example Token Claims
+
+```json
+{
+  "oid": "person-object-id",
+  "name": "John Doe",
+  "email": "john.doe@equinor.com",
+  "roles": ["engineer", "approver"],
+  "scp": "api://fusion-person/.default",
+  "aud": "0ec6e8f2-d309-4316-90e6-1d05628b5f07"
+}
+```
+
+The `roles` array shows what you can do globally. Per-context roles are usually returned in API responses.

--- a/skills/fusion-backend-dev/references/authorization-patterns.md
+++ b/skills/fusion-backend-dev/references/authorization-patterns.md
@@ -171,22 +171,36 @@ Authorization: ApiKey {api-key}
 
 Before calling an endpoint, understand what you can do:
 
-1. **Get your token**: Request from Azure AD with `api://{service}/.default` scope
+1. **Get your token**: Request from Azure AD with the appropriate scope:
+   - **Delegated** (user flow): `api://{resource-app-id}/user_impersonation` (or the specific delegated scope exposed by the service)
+   - **App-only** (client credentials): `api://{resource-app-id}/.default`
 2. **Decode the token**: Use jwt.ms or similar to see your roles/claims
 3. **Check the endpoint docs**: Look for "Required role" or "Requirement" field
 4. **Verify you have that role**: If not, ask your manager or context manager to assign it
 
 ### Example Token Claims
 
+**Delegated token** (user acting via an app):
 ```json
 {
   "oid": "person-object-id",
   "name": "John Doe",
   "email": "john.doe@equinor.com",
-  "roles": ["engineer", "approver"],
   "scp": "user_impersonation",
   "aud": "{resource-app-id}"
 }
 ```
 
-The `roles` array shows what you can do globally. Per-context roles are usually returned in API responses.
+**App-only token** (client credentials, no user context):
+```json
+{
+  "oid": "service-principal-object-id",
+  "appid": "{client-app-id}",
+  "roles": ["Application.ReadWrite"],
+  "aud": "{resource-app-id}"
+}
+```
+
+> **Key difference:** Delegated tokens carry `scp` (delegated permissions); app-only tokens carry `roles` (application permissions). A single token will not contain both.
+
+Per-context roles (e.g. ContextManager, Approver) are Fusion-level concepts returned in API responses, not Azure AD token claims.

--- a/skills/fusion-backend-dev/references/authorization-patterns.md
+++ b/skills/fusion-backend-dev/references/authorization-patterns.md
@@ -59,10 +59,10 @@ public class MustBeContextManagerRequirement : IAuthorizationRequirement
 
 | Scenario | Requirement | How to satisfy |
 | --- | --- | --- |
-| Read Context | `CanReadContext` | Any authenticated user with delegated `api://fusion-context/user_impersonation` scope |
+| Read Context | `CanReadContext` | Any authenticated user with delegated `api://{context-resource-app-id}/user_impersonation` scope |
 | Modify Context | `IsContextManager` | Must have "ContextManager" role in that context OR hold a position in it |
 | Delete Position | `CanDeletePosition` | Must be HR admin OR context manager where position exists |
-| View Person | `CanViewPerson` | Any authenticated user with delegated `api://fusion-people/user_impersonation` scope |
+| View Person | `CanViewPerson` | Any authenticated user with delegated `api://{people-resource-app-id}/user_impersonation` scope |
 
 > **Note:** Use `.default` scopes only for client-credentials (app-only) flows. For delegated (on-behalf-of-user) flows, use service-specific scopes like `user_impersonation`.
 
@@ -183,8 +183,8 @@ Before calling an endpoint, understand what you can do:
   "name": "John Doe",
   "email": "john.doe@equinor.com",
   "roles": ["engineer", "approver"],
-  "scp": "api://{resource-app-id}/.default",
-  "aud": "{app-client-id}"
+  "scp": "user_impersonation",
+  "aud": "{resource-app-id}"
 }
 ```
 

--- a/skills/fusion-backend-dev/references/authorization-patterns.md
+++ b/skills/fusion-backend-dev/references/authorization-patterns.md
@@ -10,7 +10,7 @@ Authorization: Bearer {jwt_token}
 
 The token is obtained from Azure AD using the Fusion app client ID:
 - **Client ID**: `0ec6e8f2-d309-4316-90e6-1d05628b5f07`
-- **Authority**: `https://login.microsoftonline.com/`
+- **Authority**: `https://login.microsoftonline.com/{tenant-id}/` (replace `{tenant-id}` with your Azure AD tenant ID, or use `common` / `organizations` if appropriate)
 - **Delegated scope format**: `api://{service-id}/{scope-name}`
 - **Client credentials scope format**: `api://{service-id}/.default`
 
@@ -171,7 +171,7 @@ Before calling an endpoint, understand what you can do:
   "name": "John Doe",
   "email": "john.doe@equinor.com",
   "roles": ["engineer", "approver"],
-  "scp": "api://fusion-person/.default",
+  "scp": "api://fusion-people/.default",
   "aud": "0ec6e8f2-d309-4316-90e6-1d05628b5f07"
 }
 ```

--- a/skills/fusion-backend-dev/references/authorization-patterns.md
+++ b/skills/fusion-backend-dev/references/authorization-patterns.md
@@ -59,10 +59,12 @@ public class MustBeContextManagerRequirement : IAuthorizationRequirement
 
 | Scenario | Requirement | How to satisfy |
 | --- | --- | --- |
-| Read Context | `CanReadContext` | Any authenticated user with `api://fusion-context/.default` scope |
+| Read Context | `CanReadContext` | Any authenticated user with delegated `api://fusion-context/user_impersonation` scope |
 | Modify Context | `IsContextManager` | Must have "ContextManager" role in that context OR hold a position in it |
 | Delete Position | `CanDeletePosition` | Must be HR admin OR context manager where position exists |
-| View Person | `CanViewPerson` | Any authenticated user with `api://fusion-people/.default` scope |
+| View Person | `CanViewPerson` | Any authenticated user with delegated `api://fusion-people/user_impersonation` scope |
+
+> **Note:** Use `.default` scopes only for client-credentials (app-only) flows. For delegated (on-behalf-of-user) flows, use service-specific scopes like `user_impersonation`.
 
 ---
 
@@ -108,16 +110,26 @@ Check role claims in your token to understand what you can do.
 - Ask context manager to assign role if needed
 - Check if user is responsible (position holder, manager, etc.)
 
-### 400 Bad Request with authorization detail
+### 403 Forbidden with authorization detail
 
-**Cause**: Authorization requirement validation failed
+**Cause**: Request is authenticated, but the caller does not satisfy an authorization requirement
 
-**Response example**:
+**Response example** (ProblemDetails with Fusion `error` extension):
 ```json
 {
-  "code": "REQUIREMENT_NOT_MET",
-  "message": "User must be context manager",
-  "details": { "requirement": "IsContextManager" }
+  "type": "https://docs.fusion-dev.net/development/api/errors/#403",
+  "title": "User is not authorized to access data",
+  "status": 403,
+  "detail": "User must be context manager",
+  "error": {
+    "code": "Forbidden",
+    "message": "User must be context manager",
+    "accessRequirements": [
+      { "code": "IsContextManager", "description": "Must be context manager", "outcome": "Failed", "wasEvaluated": true }
+    ]
+  },
+  "traceId": "...",
+  "timestamp": "..."
 }
 ```
 

--- a/skills/fusion-backend-dev/references/authorization-patterns.md
+++ b/skills/fusion-backend-dev/references/authorization-patterns.md
@@ -11,15 +11,24 @@ Authorization: Bearer {jwt_token}
 The token is obtained from Azure AD using the Fusion app client ID:
 - **Client ID**: `0ec6e8f2-d309-4316-90e6-1d05628b5f07`
 - **Authority**: `https://login.microsoftonline.com/`
-- **Scope format**: `api://{service-id}/.default`
+- **Delegated scope format**: `api://{service-id}/{scope-name}`
+- **Client credentials scope format**: `api://{service-id}/.default`
 
 ### Example Scopes
+
+**Delegated scopes** (user/app acting on behalf of a signed-in user):
 
 | Service | Scope |
 | --- | --- |
 | People | `api://0ec6e8f2-d309-4316-90e6-1d05628b5f07/people` |
 | Org | `api://0ec6e8f2-d309-4316-90e6-1d05628b5f07/org` |
 | Context | `api://0ec6e8f2-d309-4316-90e6-1d05628b5f07/context` |
+
+**Application scope** (client credentials / app-only access):
+
+| Flow | Scope |
+| --- | --- |
+| Client credentials | `api://0ec6e8f2-d309-4316-90e6-1d05628b5f07/.default` |
 
 ---
 

--- a/skills/fusion-backend-dev/references/authorization-patterns.md
+++ b/skills/fusion-backend-dev/references/authorization-patterns.md
@@ -8,11 +8,11 @@ All Fusion services require an Azure AD access token in the Authorization header
 Authorization: Bearer {jwt_token}
 ```
 
-The token is obtained from Azure AD using the Fusion app client ID:
-- **Client ID**: `0ec6e8f2-d309-4316-90e6-1d05628b5f07`
+The token is obtained from Azure AD using the Fusion app registration:
+- **Client ID**: `{app-client-id}` (obtain from your Fusion app registration)
 - **Authority**: `https://login.microsoftonline.com/{tenant-id}/` (replace `{tenant-id}` with your Azure AD tenant ID, or use `common` / `organizations` if appropriate)
-- **Delegated scope format**: `api://{service-id}/{scope-name}`
-- **Client credentials scope format**: `api://{service-id}/.default`
+- **Delegated scope format**: `api://{resource-app-id}/{scope-name}`
+- **Client credentials scope format**: `api://{resource-app-id}/.default`
 
 ### Example Scopes
 
@@ -20,15 +20,15 @@ The token is obtained from Azure AD using the Fusion app client ID:
 
 | Service | Scope |
 | --- | --- |
-| People | `api://0ec6e8f2-d309-4316-90e6-1d05628b5f07/people` |
-| Org | `api://0ec6e8f2-d309-4316-90e6-1d05628b5f07/org` |
-| Context | `api://0ec6e8f2-d309-4316-90e6-1d05628b5f07/context` |
+| People | `api://{resource-app-id}/people` |
+| Org | `api://{resource-app-id}/org` |
+| Context | `api://{resource-app-id}/context` |
 
 **Application scope** (client credentials / app-only access):
 
 | Flow | Scope |
 | --- | --- |
-| Client credentials | `api://0ec6e8f2-d309-4316-90e6-1d05628b5f07/.default` |
+| Client credentials | `api://{resource-app-id}/.default` |
 
 ---
 
@@ -171,8 +171,8 @@ Before calling an endpoint, understand what you can do:
   "name": "John Doe",
   "email": "john.doe@equinor.com",
   "roles": ["engineer", "approver"],
-  "scp": "api://fusion-people/.default",
-  "aud": "0ec6e8f2-d309-4316-90e6-1d05628b5f07"
+  "scp": "api://{resource-app-id}/.default",
+  "aud": "{app-client-id}"
 }
 ```
 

--- a/skills/fusion-backend-dev/references/authorization-patterns.md
+++ b/skills/fusion-backend-dev/references/authorization-patterns.md
@@ -87,7 +87,8 @@ Fusion services assign roles per user per resource. Example: roles in a context:
 - **Contributor**: Can edit owned resources; read access to context
 - **Viewer**: Read-only access to context and positions
 
-Check role claims in your token to understand what you can do.
+Check your token's delegated `scp` claim or app roles to confirm coarse service/application permissions.
+For per-context Fusion roles such as `ContextManager`, `Approver`, or `Contributor`, use the relevant Fusion endpoint(s) or resource responses, because those roles are determined within Fusion and are not Azure AD token claims.
 
 ---
 

--- a/skills/fusion-backend-dev/references/authorization-patterns.md
+++ b/skills/fusion-backend-dev/references/authorization-patterns.md
@@ -20,10 +20,11 @@ The token is obtained from Azure AD using the Fusion app registration:
 
 | Service | Scope |
 | --- | --- |
-| People | `api://{resource-app-id}/people` |
-| Org | `api://{resource-app-id}/org` |
-| Context | `api://{resource-app-id}/context` |
+| People | `api://{resource-app-id}/user_impersonation` |
+| Org | `api://{resource-app-id}/user_impersonation` |
+| Context | `api://{resource-app-id}/user_impersonation` |
 
+> Delegated scope names are defined by each service's Azure AD app registration. `user_impersonation` is a common pattern, but you must verify the actual delegated scope exposed by the target service before requesting a token.
 **Application scope** (client credentials / app-only access):
 
 | Flow | Scope |

--- a/skills/fusion-backend-dev/references/authorization-patterns.md
+++ b/skills/fusion-backend-dev/references/authorization-patterns.md
@@ -2,7 +2,7 @@
 
 ## Request Authentication
 
-All Fusion services require an Azure AD access token in the Authorization header:
+Most Fusion services require an Azure AD access token in the Authorization header (see [API Key Authentication](#api-key-authentication-special-cases) for exceptions):
 
 ```
 Authorization: Bearer {jwt_token}

--- a/skills/fusion-backend-dev/references/cqrs-reference.md
+++ b/skills/fusion-backend-dev/references/cqrs-reference.md
@@ -197,12 +197,12 @@ Some queries support fluent building:
 
 ```csharp
 // Usage:
-var query = new GetContextQuery(contextId)
+GetContextQuery query = new GetContextQuery(contextId)
     .WithPositions()
     .WithManager()
     .WithResponsibilities();
 
-var context = await mediator.Send(query);
+ContextDto context = await mediator.Send(query);
 ```
 
 **What this enables**: Load only the data you need (optimization)
@@ -318,19 +318,21 @@ Response: 500 Internal Server Error
 ### Idempotent Creation
 
 ```csharp
-public async Task<PositionDto> Handle(CreatePositionCommand request)
+public async Task<PositionDto> Handle(
+    CreatePositionCommand request,
+    CancellationToken cancellationToken)
 {
     // Check if already exists (idempotent key)
-    var existing = await _db.Positions
-        .FirstOrDefaultAsync(p => p.ExternalId == request.ExternalId);
+    DbPosition? existing = await _db.Positions
+        .FirstOrDefaultAsync(p => p.ExternalId == request.ExternalId, cancellationToken);
     
     if (existing != null)
         return _mapper.Map<PositionDto>(existing);  // Return existing
     
     // Create new
-    var position = new Position { ... };
-    await _db.SaveChangesAsync();
-    await _mediator.Publish(new PositionCreated(position));
+    DbPosition position = new DbPosition { ... };
+    await _db.SaveChangesAsync(cancellationToken);
+    await _mediator.Publish(new PositionCreated(position), cancellationToken);
     
     return _mapper.Map<PositionDto>(position);
 }
@@ -339,16 +341,18 @@ public async Task<PositionDto> Handle(CreatePositionCommand request)
 ### Soft Delete
 
 ```csharp
-public async Task<bool> Handle(DeleteContextCommand request)
+public async Task<bool> Handle(
+    DeleteContextCommand request,
+    CancellationToken cancellationToken)
 {
-    var context = await _db.Contexts.FindAsync(request.ContextId);
+    DbFusionContext? context = await _db.Contexts.FindAsync(request.ContextId);
     
     context.IsArchived = true;
     context.ArchivedAt = DateTime.UtcNow;
     context.ArchivedBy = _currentUser.Id;
     
-    await _db.SaveChangesAsync();
-    await _mediator.Publish(new ContextArchived(context));
+    await _db.SaveChangesAsync(cancellationToken);
+    await _mediator.Publish(new ContextArchived(context), cancellationToken);
     
     return true;
 }
@@ -357,30 +361,32 @@ public async Task<bool> Handle(DeleteContextCommand request)
 ### Transactional Consistency
 
 ```csharp
-public async Task<ContextDto> Handle(CreateContextCommand request)
+public async Task<ContextDto> Handle(
+    CreateContextCommand request,
+    CancellationToken cancellationToken)
 {
-    using var transaction = await _db.Database.BeginTransactionAsync();
+    using IDbContextTransaction transaction = await _db.Database.BeginTransactionAsync(cancellationToken);
     
     try
     {
-        var context = new Context { ... };
-        await _db.Contexts.AddAsync(context);
+        DbFusionContext context = new DbFusionContext { ... };
+        await _db.Contexts.AddAsync(context, cancellationToken);
         
         // Create default positions, approvals, etc. in same transaction
-        var defaultPosition = new Position { ContextId = context.Id, ... };
-        await _db.Positions.AddAsync(defaultPosition);
+        DbPosition defaultPosition = new DbPosition { ContextId = context.Id, ... };
+        await _db.Positions.AddAsync(defaultPosition, cancellationToken);
         
-        await _db.SaveChangesAsync();
-        await transaction.CommitAsync();
+        await _db.SaveChangesAsync(cancellationToken);
+        await transaction.CommitAsync(cancellationToken);
         
         // Publish events AFTER transaction succeeds
-        await _mediator.Publish(new ContextCreated(context));
+        await _mediator.Publish(new ContextCreated(context), cancellationToken);
         
         return _mapper.Map<ContextDto>(context);
     }
     catch
     {
-        await transaction.RollbackAsync();
+        await transaction.RollbackAsync(cancellationToken);
         throw;
     }
 }

--- a/skills/fusion-backend-dev/references/cqrs-reference.md
+++ b/skills/fusion-backend-dev/references/cqrs-reference.md
@@ -181,7 +181,7 @@ public class GetContextQuery : IRequest<ContextDto>
 ```csharp
 public class ListContextsQuery : IRequest<List<ContextDto>>
 {
-    public string Type { get; set; }  // Optional filter
+    public string? Type { get; set; }  // Optional filter
     public bool IncludeArchived { get; set; }
     public int? Take { get; set; }  // Pagination
     public int? Skip { get; set; }
@@ -192,11 +192,11 @@ public class ListContextsQuery : IRequest<List<ContextDto>>
 
 ### Fluent Builder Pattern
 
-Some queries support fluent building:
+Some queries support fluent building (illustrative pseudo-code — actual query classes vary by service):
 
 ```csharp
-// Usage:
-GetContextQuery query = new GetContextQuery(contextId)
+// Fluent builder query example:
+GetContextQuery query = new GetContextQuery { ContextId = contextId }
     .WithPositions()
     .WithManager()
     .WithResponsibilities();

--- a/skills/fusion-backend-dev/references/cqrs-reference.md
+++ b/skills/fusion-backend-dev/references/cqrs-reference.md
@@ -251,7 +251,7 @@ Response: 400 Bad Request
   "type": "https://tools.ietf.org/html/rfc7231#section-6.5.1",
   "title": "One or more validation errors occurred.",
   "status": 400,
-  "error": { "code": "ModelValidationError", "message": "Model contained 1 errors" },
+  "error": { "code": "ModelValidationError", "message": "Model contained 1 error" },
   "errors": { "startDate": ["Must be before end date"] },
   "traceId": "..."
 }

--- a/skills/fusion-backend-dev/references/cqrs-reference.md
+++ b/skills/fusion-backend-dev/references/cqrs-reference.md
@@ -334,12 +334,15 @@ public async Task<PositionDto> Handle(
     CreatePositionCommand request,
     CancellationToken cancellationToken)
 {
-    // Check if already exists (idempotent key)
-    DbPosition? existing = await _db.Positions
-        .FirstOrDefaultAsync(p => p.ExternalId == request.ExternalId, cancellationToken);
-    
-    if (existing != null)
-        return _mapper.Map<PositionDto>(existing);  // Return existing
+    // Check if already exists only when an idempotent key was provided
+    if (!string.IsNullOrWhiteSpace(request.ExternalId))
+    {
+        DbPosition? existing = await _db.Positions
+            .FirstOrDefaultAsync(p => p.ExternalId == request.ExternalId, cancellationToken);
+
+        if (existing != null)
+            return _mapper.Map<PositionDto>(existing);  // Return existing
+    }
     
     // Create new
     DbPosition position = new DbPosition { ... };

--- a/skills/fusion-backend-dev/references/cqrs-reference.md
+++ b/skills/fusion-backend-dev/references/cqrs-reference.md
@@ -1,0 +1,386 @@
+# CQRS: Commands, Queries, and Handlers
+
+## Command/Query Pattern Basics
+
+Fusion services use **CQRS** (Command Query Responsibility Segregation) via MediatR:
+
+### Commands (Write Operations)
+
+A command represents an intent to change state:
+
+```csharp
+// Example command
+public class CreatePositionCommand : IRequest<PositionDto>
+{
+    public string ContextId { get; set; }
+    public string Title { get; set; }
+    public DateTime StartDate { get; set; }
+    public DateTime EndDate { get; set; }
+}
+```
+
+**Characteristics**:
+- Imperative name (Create, Update, Delete, Assign, Publish)
+- Returns a result (`IRequest<TResponse>`)
+- Goes through validation pipeline
+- May trigger events
+- Executed once (idempotent when possible)
+
+### Queries (Read Operations)
+
+A query represents a request for data:
+
+```csharp
+// Example query
+public class GetPositionsQuery : IRequest<List<PositionDto>>
+{
+    public string ContextId { get; set; }
+    public bool IncludeArchived { get; set; }
+}
+```
+
+**Characteristics**:
+- Indicative name (Get, List, Find, Search)
+- Returns data (`IRequest<TResponse>`)
+- Should be idempotent (no side effects)
+- Can be cached
+- Multiple executions are safe
+
+### Handlers
+
+Each command/query has a handler that processes it:
+
+```csharp
+// Command handler
+public class CreatePositionHandler : IRequestHandler<CreatePositionCommand, PositionDto>
+{
+    public async Task<PositionDto> Handle(CreatePositionCommand request, ...)
+    {
+        // Validate input
+        // Check authorization
+        // Apply business logic
+        // Save to database
+        // Publish events
+        // Return result
+    }
+}
+
+// Query handler
+public class GetPositionsHandler : IRequestHandler<GetPositionsQuery, List<PositionDto>>
+{
+    public async Task<List<PositionDto>> Handle(GetPositionsQuery request, ...)
+    {
+        // Query database
+        // Apply filters
+        // Return data
+    }
+}
+```
+
+---
+
+## Handler Lifecycle
+
+When you call a command/query, this happens:
+
+```
+1. Handler created (dependency injection)
+2. Validation behaviors run
+   ├─ Validate input schema
+   └─ Validate business rules
+3. Authorization behavior runs
+   └─ Check if user has permission
+4. Logging/telemetry begins
+5. Handle() method executes
+6. Response captured
+7. Events published (if any)
+8. Logging/telemetry ends
+9. Response returned
+```
+
+---
+
+## Command Patterns
+
+### Create Pattern
+
+```csharp
+public class CreateContextCommand : IRequest<ContextDto>
+{
+    public string Title { get; set; }
+    public string Type { get; set; }  // ProjectContext, ProgramContext, etc.
+    public DateTime StartDate { get; set; }
+    public DateTime EndDate { get; set; }
+}
+
+// Handler responsibilities:
+// 1. Validate: Title not empty, dates valid, type recognized
+// 2. Check auth: User is admin or has create permission
+// 3. Create: Context entity with initial state
+// 4. Persist: Save to database
+// 5. Publish: ContextCreated event
+// 6. Return: ContextDto with new ID
+```
+
+### Update Pattern
+
+```csharp
+public class UpdateContextCommand : IRequest<ContextDto>
+{
+    public string ContextId { get; set; }
+    public string Title { get; set; }  // Optional
+    public DateTime? EndDate { get; set; }  // Optional
+    // Only changed fields included
+}
+
+// Handler responsibilities:
+// 1. Load: Fetch current context
+// 2. Validate: New values are valid
+// 3. Check auth: User is context manager
+// 4. Update: Modify only specified fields
+// 5. Persist: Save changes
+// 6. Publish: ContextModified event
+// 7. Return: Updated ContextDto
+```
+
+### Delete Pattern
+
+```csharp
+public class DeleteContextCommand : IRequest<bool>
+{
+    public string ContextId { get; set; }
+}
+
+// Handler responsibilities:
+// 1. Load: Fetch context
+// 2. Check auth: Only admin or context owner
+// 3. Validate: Can delete (no active positions, etc.)
+// 4. Delete: Mark as archived (soft delete) or remove
+// 5. Persist: Save deletion state
+// 6. Publish: ContextDeleted event
+// 7. Return: Success boolean
+```
+
+---
+
+## Query Patterns
+
+### Single Item
+
+```csharp
+public class GetContextQuery : IRequest<ContextDto>
+{
+    public string ContextId { get; set; }
+}
+
+// Handler: Fetch by ID, apply read authorization, return
+```
+
+### List with Filtering
+
+```csharp
+public class ListContextsQuery : IRequest<List<ContextDto>>
+{
+    public string Type { get; set; }  // Optional filter
+    public bool IncludeArchived { get; set; }
+    public int? Take { get; set; }  // Pagination
+    public int? Skip { get; set; }
+}
+
+// Handler: Query with optional filters, paginate, return list
+```
+
+### Fluent Builder Pattern
+
+Some queries support fluent building:
+
+```csharp
+// Usage:
+var query = new GetContextQuery(contextId)
+    .WithPositions()
+    .WithManager()
+    .WithResponsibilities();
+
+var context = await mediator.Send(query);
+```
+
+**What this enables**: Load only the data you need (optimization)
+
+---
+
+## Validation & Authorization
+
+### Validation Flow
+
+```
+1. Input validation: Are required fields present? Correct types?
+2. Business rule validation: Does this make sense?
+   - StartDate before EndDate?
+   - Context not archived?
+   - Quota not exceeded?
+3. Authorization check: Does user have permission?
+```
+
+### Authorization Requirements
+
+```csharp
+public class CreatePositionCommand : IRequest<PositionDto>, ITrackableRequest
+{
+    public string ContextId { get; set; }
+    public string Title { get; set; }
+}
+
+// Implicit requirement:
+// Must satisfy "IsContextManager" for ContextId
+// This is checked before Handle() runs
+```
+
+**If authorization fails**: `403 Forbidden` returned; Handle() never runs
+
+---
+
+## Error Handling
+
+### Validation Errors
+
+Command fails in validation phase:
+
+```
+Response: 400 Bad Request
+{
+  "code": "VALIDATION_FAILED",
+  "details": [
+    { "field": "startDate", "message": "Must be before end date" }
+  ]
+}
+```
+
+### Authorization Errors
+
+Command fails in authorization phase:
+
+```
+Response: 403 Forbidden
+{
+  "code": "FORBIDDEN",
+  "message": "Only context managers can create positions"
+}
+```
+
+### Business Rule Violations
+
+Handler executes but business rule check fails:
+
+```csharp
+if (context.IsArchived)
+{
+  throw new BusinessRuleException("Cannot modify archived context");
+}
+
+// Response: 422 Unprocessable Entity
+{
+  "code": "BUSINESS_RULE_VIOLATION",
+  "message": "Cannot modify archived context"
+}
+```
+
+### Unexpected Errors
+
+Handler crashes or unhandled exception:
+
+```
+Response: 500 Internal Server Error
+{
+  "code": "INTERNAL_SERVER_ERROR",
+  "message": "An unexpected error occurred",
+  "traceId": "uuid-for-logs"  // Share with support
+}
+```
+
+---
+
+## Choosing Command vs Query
+
+| Aspect | Command | Query |
+| --- | --- | --- |
+| **Intent** | Change state | Read state |
+| **Side effects** | Expected (save to DB, publish events) | None (read-only) |
+| **Idempotent** | Usually not (or explicitly handled) | Always |
+| **Can cache** | No | Yes |
+| **Execution** | Once, carefully | Multiple times safe |
+| **Example** | CreatePosition, UpdateContext, AssignRole | GetContext, ListPositions, SearchPeople |
+
+---
+
+## Common Handler Patterns
+
+### Idempotent Creation
+
+```csharp
+public async Task<PositionDto> Handle(CreatePositionCommand request)
+{
+    // Check if already exists (idempotent key)
+    var existing = await _db.Positions
+        .FirstOrDefaultAsync(p => p.ExternalId == request.ExternalId);
+    
+    if (existing != null)
+        return _mapper.Map<PositionDto>(existing);  // Return existing
+    
+    // Create new
+    var position = new Position { ... };
+    await _db.SaveChangesAsync();
+    await _mediator.Publish(new PositionCreated(position));
+    
+    return _mapper.Map<PositionDto>(position);
+}
+```
+
+### Soft Delete
+
+```csharp
+public async Task<bool> Handle(DeleteContextCommand request)
+{
+    var context = await _db.Contexts.FindAsync(request.ContextId);
+    
+    context.IsArchived = true;
+    context.ArchivedAt = DateTime.UtcNow;
+    context.ArchivedBy = _currentUser.Id;
+    
+    await _db.SaveChangesAsync();
+    await _mediator.Publish(new ContextArchived(context));
+    
+    return true;
+}
+```
+
+### Transactional Consistency
+
+```csharp
+public async Task<ContextDto> Handle(CreateContextCommand request)
+{
+    using var transaction = await _db.Database.BeginTransactionAsync();
+    
+    try
+    {
+        var context = new Context { ... };
+        await _db.Contexts.AddAsync(context);
+        
+        // Create default positions, approvals, etc. in same transaction
+        var defaultPosition = new Position { ContextId = context.Id, ... };
+        await _db.Positions.AddAsync(defaultPosition);
+        
+        await _db.SaveChangesAsync();
+        await transaction.CommitAsync();
+        
+        // Publish events AFTER transaction succeeds
+        await _mediator.Publish(new ContextCreated(context));
+        
+        return _mapper.Map<ContextDto>(context);
+    }
+    catch
+    {
+        await transaction.RollbackAsync();
+        throw;
+    }
+}
+```

--- a/skills/fusion-backend-dev/references/cqrs-reference.md
+++ b/skills/fusion-backend-dev/references/cqrs-reference.md
@@ -243,15 +243,17 @@ public class CreatePositionCommand : IRequest<PositionDto>, ITrackableRequest
 
 ### Validation Errors
 
-Command fails in validation phase:
+Command fails in validation phase (ProblemDetails envelope):
 
 ```
 Response: 400 Bad Request
 {
-  "code": "VALIDATION_FAILED",
-  "details": [
-    { "field": "startDate", "message": "Must be before end date" }
-  ]
+  "type": "https://tools.ietf.org/html/rfc7231#section-6.5.1",
+  "title": "One or more validation errors occurred.",
+  "status": 400,
+  "error": { "code": "ModelValidationError", "message": "Model contained 1 errors" },
+  "errors": { "startDate": ["Must be before end date"] },
+  "traceId": "..."
 }
 ```
 
@@ -262,8 +264,11 @@ Command fails in authorization phase:
 ```
 Response: 403 Forbidden
 {
-  "code": "FORBIDDEN",
-  "message": "Only context managers can create positions"
+  "type": "https://docs.fusion-dev.net/development/api/errors/#403",
+  "title": "User is not authorized to access data",
+  "status": 403,
+  "error": { "code": "Forbidden", "message": "Only context managers can create positions" },
+  "traceId": "..."
 }
 ```
 
@@ -274,13 +279,19 @@ Handler executes but business rule check fails:
 ```csharp
 if (context.IsArchived)
 {
-  throw new BusinessRuleException("Cannot modify archived context");
+  throw new InvalidOperationException("Cannot modify archived context");
 }
+```
 
-// Response: 422 Unprocessable Entity
+```
+Response: 400 Bad Request
 {
-  "code": "BUSINESS_RULE_VIOLATION",
-  "message": "Cannot modify archived context"
+  "type": "https://tools.ietf.org/html/rfc7231#section-6.5.1",
+  "title": "Invalid operation",
+  "status": 400,
+  "detail": "Cannot modify archived context",
+  "error": { "code": "InvalidOperation", "message": "Cannot modify archived context" },
+  "traceId": "..."
 }
 ```
 
@@ -291,9 +302,11 @@ Handler crashes or unhandled exception:
 ```
 Response: 500 Internal Server Error
 {
-  "code": "INTERNAL_SERVER_ERROR",
-  "message": "An unexpected error occurred",
-  "traceId": "uuid-for-logs"  // Share with support
+  "type": "https://tools.ietf.org/html/rfc7231#section-6.6.1",
+  "title": "Unexpected error",
+  "status": 500,
+  "error": { "code": "UnexpectedError", "message": "An unexpected error occurred" },
+  "traceId": "00-abc123..."  // Share with support
 }
 ```
 

--- a/skills/fusion-backend-dev/references/cqrs-reference.md
+++ b/skills/fusion-backend-dev/references/cqrs-reference.md
@@ -16,6 +16,7 @@ public class CreatePositionCommand : IRequest<PositionDto>
     public string Title { get; set; }
     public DateTime StartDate { get; set; }
     public DateTime EndDate { get; set; }
+    public string? ExternalId { get; set; }  // Optional idempotency key
 }
 ```
 

--- a/skills/fusion-backend-dev/references/cqrs-reference.md
+++ b/skills/fusion-backend-dev/references/cqrs-reference.md
@@ -129,9 +129,8 @@ public class CreateContextCommand : IRequest<ContextDto>
 public class UpdateContextCommand : IRequest<ContextDto>
 {
     public string ContextId { get; set; }
-    public string Title { get; set; }  // Optional
-    public DateTime? EndDate { get; set; }  // Optional
-    // Only changed fields included
+    public string? Title { get; set; }  // Optional — null means unchanged
+    public DateTime? EndDate { get; set; }  // Optional — null means unchanged
 }
 
 // Handler responsibilities:
@@ -345,7 +344,8 @@ public async Task<bool> Handle(
     DeleteContextCommand request,
     CancellationToken cancellationToken)
 {
-    DbFusionContext? context = await _db.Contexts.FindAsync(request.ContextId);
+    DbFusionContext context = await _db.Contexts.FindAsync(request.ContextId)
+        ?? throw new NotFoundException($"Context {request.ContextId} not found");
     
     context.IsArchived = true;
     context.ArchivedAt = DateTime.UtcNow;

--- a/skills/fusion-backend-dev/references/integration-patterns.md
+++ b/skills/fusion-backend-dev/references/integration-patterns.md
@@ -137,12 +137,27 @@ X-Fusion-Delivery-Id: {uuid}
 The receiver validates the signature:
 
 ```csharp
-// Compute signature with shared secret
-var hmac = HMAC.SHA256(secret, requestBody);
-var signature = "sha256=" + Convert.ToHexString(hmac);
+var keyBytes = System.Text.Encoding.UTF8.GetBytes(secret);
+var bodyBytes = System.Text.Encoding.UTF8.GetBytes(requestBody);
+byte[] computedSignature;
 
-// Compare with header
-if (signature != request.Headers["X-Fusion-Signature"])
+using (var hmac = new System.Security.Cryptography.HMACSHA256(keyBytes))
+{
+  computedSignature = hmac.ComputeHash(bodyBytes);
+}
+
+var headerValue = request.Headers["X-Fusion-Signature"].ToString();
+const string signaturePrefix = "sha256=";
+
+if (!headerValue.StartsWith(signaturePrefix, StringComparison.Ordinal))
+{
+  // Missing or malformed signature; reject it
+  return 401 Unauthorized;
+}
+
+var providedSignature = Convert.FromHexString(headerValue.Substring(signaturePrefix.Length));
+
+if (!System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(computedSignature, providedSignature))
 {
   // Request may be spoofed; reject it
   return 401 Unauthorized;
@@ -212,7 +227,7 @@ public async Task<PersonDto> GetPerson(string id)
     return cached;
   
   var person = await _sapClient.GetPerson(id);
-  _cache.Set($"person:{id}", person, expiration: 1hour);
+  _cache.Set($"person:{id}", person, expiration: TimeSpan.FromHours(1));
   return person;
 }
 ```

--- a/skills/fusion-backend-dev/references/integration-patterns.md
+++ b/skills/fusion-backend-dev/references/integration-patterns.md
@@ -133,16 +133,25 @@ X-Fusion-Delivery-Id: {uuid}
 
 ### Signature Validation
 
-The receiver validates the signature:
+The receiver validates the signature using the raw request body bytes:
 
 ```csharp
 byte[] keyBytes = System.Text.Encoding.UTF8.GetBytes(secret);
-byte[] bodyBytes = System.Text.Encoding.UTF8.GetBytes(requestBody);
-byte[] computedSignature;
 
-using (HMACSHA256 hmac = new System.Security.Cryptography.HMACSHA256(keyBytes))
+// Read raw body bytes to ensure signature matches exactly
+request.EnableBuffering();
+byte[] bodyBytes;
+using (var bodyStream = new System.IO.MemoryStream())
 {
-  computedSignature = hmac.ComputeHash(bodyBytes);
+    await request.Body.CopyToAsync(bodyStream);
+    bodyBytes = bodyStream.ToArray();
+    request.Body.Position = 0;
+}
+
+byte[] computedSignature;
+using (var hmac = new System.Security.Cryptography.HMACSHA256(keyBytes))
+{
+    computedSignature = hmac.ComputeHash(bodyBytes);
 }
 
 string headerValue = request.Headers["X-Fusion-Signature"].ToString();
@@ -150,16 +159,14 @@ const string signaturePrefix = "sha256=";
 
 if (!headerValue.StartsWith(signaturePrefix, StringComparison.Ordinal))
 {
-  // Missing or malformed signature; reject it
-  return 401 Unauthorized;
+    return Results.Unauthorized();  // Missing or malformed signature
 }
 
 byte[] providedSignature = Convert.FromHexString(headerValue.Substring(signaturePrefix.Length));
 
 if (!System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(computedSignature, providedSignature))
 {
-  // Request may be spoofed; reject it
-  return 401 Unauthorized;
+    return Results.Unauthorized();  // Request may be spoofed
 }
 ```
 

--- a/skills/fusion-backend-dev/references/integration-patterns.md
+++ b/skills/fusion-backend-dev/references/integration-patterns.md
@@ -100,7 +100,7 @@ public class SAPPerson
 }
 
 // Mapper converts between formats
-var fusion = mapper.Map<PersonDto>(sapPerson);
+PersonDto fusion = mapper.Map<PersonDto>(sapPerson);
 ```
 
 ---
@@ -136,16 +136,16 @@ X-Fusion-Delivery-Id: {uuid}
 The receiver validates the signature:
 
 ```csharp
-var keyBytes = System.Text.Encoding.UTF8.GetBytes(secret);
-var bodyBytes = System.Text.Encoding.UTF8.GetBytes(requestBody);
+byte[] keyBytes = System.Text.Encoding.UTF8.GetBytes(secret);
+byte[] bodyBytes = System.Text.Encoding.UTF8.GetBytes(requestBody);
 byte[] computedSignature;
 
-using (var hmac = new System.Security.Cryptography.HMACSHA256(keyBytes))
+using (HMACSHA256 hmac = new System.Security.Cryptography.HMACSHA256(keyBytes))
 {
   computedSignature = hmac.ComputeHash(bodyBytes);
 }
 
-var headerValue = request.Headers["X-Fusion-Signature"].ToString();
+string headerValue = request.Headers["X-Fusion-Signature"].ToString();
 const string signaturePrefix = "sha256=";
 
 if (!headerValue.StartsWith(signaturePrefix, StringComparison.Ordinal))
@@ -154,7 +154,7 @@ if (!headerValue.StartsWith(signaturePrefix, StringComparison.Ordinal))
   return 401 Unauthorized;
 }
 
-var providedSignature = Convert.FromHexString(headerValue.Substring(signaturePrefix.Length));
+byte[] providedSignature = Convert.FromHexString(headerValue.Substring(signaturePrefix.Length));
 
 if (!System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(computedSignature, providedSignature))
 {
@@ -173,9 +173,9 @@ Services handle external API calls carefully:
 
 ```csharp
 // All external calls have timeouts
-var timeout = TimeSpan.FromSeconds(30);
-using var cts = new CancellationTokenSource(timeout);
-var response = await _httpClient.GetAsync(url, cts.Token);
+TimeSpan timeout = TimeSpan.FromSeconds(30);
+using CancellationTokenSource cts = new CancellationTokenSource(timeout);
+HttpResponseMessage response = await _httpClient.GetAsync(url, cts.Token);
 ```
 
 **Why**: Prevents a slow external API from blocking the entire service
@@ -201,13 +201,13 @@ If external integration fails:
 ```csharp
 try
 {
-  var sap = await _sapClient.GetPerson(personId);
+  SAPPersonDto sap = await _sapClient.GetPerson(personId);
   return enriched(sap);
 }
 catch (SAPUnavailableException)
 {
   // SAP is down; use cached data or return minimal response
-  var cached = _cache.Get(personId);
+  PersonDto? cached = _cache.Get(personId);
   return cached ?? new MinimalPersonDto();
 }
 ```
@@ -221,11 +221,11 @@ catch (SAPUnavailableException)
 ```csharp
 public async Task<PersonDto> GetPerson(string id)
 {
-  var cached = _cache.Get<PersonDto>($"person:{id}");
+  PersonDto? cached = _cache.Get<PersonDto>($"person:{id}");
   if (cached != null)
     return cached;
   
-  var person = await _sapClient.GetPerson(id);
+  PersonDto person = await _sapClient.GetPerson(id);
   _cache.Set($"person:{id}", person, expiration: TimeSpan.FromHours(1));
   return person;
 }
@@ -258,7 +258,7 @@ public interface IExternalApiClient
 public class HttpExternalApiClient : IExternalApiClient { }
 
 // Testing: Mock
-public class MockExternalApiClient : IExternalApiClient
+public class TestExternalApiClient : IExternalApiClient
 {
   public Task<PersonDto> GetPerson(string id)
   {

--- a/skills/fusion-backend-dev/references/integration-patterns.md
+++ b/skills/fusion-backend-dev/references/integration-patterns.md
@@ -183,6 +183,11 @@ catch (FormatException)
     return Results.Unauthorized();  // Malformed signature
 }
 
+if (providedSignature.Length != computedSignature.Length)
+{
+    return Results.Unauthorized();  // Signature length mismatch
+}
+
 if (!System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(
     computedSignature, providedSignature))
 {

--- a/skills/fusion-backend-dev/references/integration-patterns.md
+++ b/skills/fusion-backend-dev/references/integration-patterns.md
@@ -107,38 +107,44 @@ PersonDto fusion = mapper.Map<PersonDto>(sapPerson);
 
 ## Webhook Handling
 
-When external systems call Fusion (Fusion receives webhooks):
+> **Note:** The following describes webhook patterns observed in the Fusion ecosystem. Specific header names, signature formats, and registration endpoints vary by service and external system. Always verify the webhook contract in the target service's documentation or source code.
 
-### Webhook Registration
+### Receiving Webhooks from External Systems
 
-```
-PUT /api/v1/webhooks
-{
-  "url": "https://external-system.com/fusion-updates",
-  "events": ["ContextCreated", "PositionAssigned"],
-  "secret": "webhook-secret"  // For signature validation
-}
-```
-
-### Webhook Delivery
+Some Fusion services receive webhooks from external systems (e.g. CommonLib). The external system delivers events to a registered callback URL:
 
 ```
-POST https://external-system.com/fusion-updates
+POST https://{fusion-host}/api/webhook/inbound
 Content-Type: application/json
-X-Fusion-Signature: sha256={hmac_signature}
-X-Fusion-Delivery-Id: {uuid}
+x-commonlib-sig: {signature}  // Signature header name varies by provider
 
 { /* event body */ }
 ```
 
-### Signature Validation
+The receiving service should validate the signature header against a shared secret. In practice, the specific header name and signature algorithm depend on the external provider's webhook contract.
 
-The receiver validates the signature using the raw request body bytes:
+### Registering Webhooks
+
+Webhook registration is typically managed by the external system's API, not Fusion's. For example, Fusion's CommonLib integration subscribes via the external system's endpoint:
+
+```json
+{
+  "callbackUrl": "https://{fusion-host}/api/webhook/inbound",
+  "secret": "{shared-secret}",
+  "library": "ProjectMaster",
+  "enabled": true
+}
+```
+
+### Signature Validation (Illustrative)
+
+The following illustrates a general HMAC signature validation pattern. The specific algorithm (SHA-1, SHA-256), header name, and signature format depend on the provider:
 
 ```csharp
+// Illustrative pattern — verify actual header name, algorithm, and format
+// with the specific webhook provider's documentation
 byte[] keyBytes = System.Text.Encoding.UTF8.GetBytes(secret);
 
-// Read raw body bytes to ensure signature matches exactly
 request.EnableBuffering();
 byte[] bodyBytes;
 using (var bodyStream = new System.IO.MemoryStream())
@@ -148,39 +154,35 @@ using (var bodyStream = new System.IO.MemoryStream())
     request.Body.Position = 0;
 }
 
+// Algorithm depends on provider (HMACSHA1, HMACSHA256, etc.)
 byte[] computedSignature;
 using (var hmac = new System.Security.Cryptography.HMACSHA256(keyBytes))
 {
     computedSignature = hmac.ComputeHash(bodyBytes);
 }
 
-string headerValue = request.Headers["X-Fusion-Signature"].ToString();
-const string signaturePrefix = "sha256=";
+string headerValue = request.Headers["x-provider-signature"].ToString();
 
-if (!headerValue.StartsWith(signaturePrefix, StringComparison.Ordinal))
+if (string.IsNullOrEmpty(headerValue))
 {
-    return Results.Unauthorized();  // Missing or malformed signature
+    return Results.Unauthorized();  // Missing signature
 }
 
-string providedSignatureHex = headerValue.Substring(signaturePrefix.Length);
-if (providedSignatureHex.Length != computedSignature.Length * 2)
-{
-    return Results.Unauthorized();  // Malformed signature length
-}
-
+// Compare using constant-time comparison to prevent timing attacks
 byte[] providedSignature;
 try
 {
-    providedSignature = Convert.FromHexString(providedSignatureHex);
+    providedSignature = Convert.FromHexString(headerValue);
 }
 catch (FormatException)
 {
-    return Results.Unauthorized();  // Malformed signature encoding
+    return Results.Unauthorized();  // Malformed signature
 }
 
-if (!System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(computedSignature, providedSignature))
+if (!System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(
+    computedSignature, providedSignature))
 {
-    return Results.Unauthorized();  // Request may be spoofed
+    return Results.Unauthorized();  // Signature mismatch
 }
 ```
 

--- a/skills/fusion-backend-dev/references/integration-patterns.md
+++ b/skills/fusion-backend-dev/references/integration-patterns.md
@@ -75,9 +75,11 @@ When Fusion services call external systems (outside Equinor):
 ### Pattern: API Keys & Secrets
 
 Credentials stored in:
-- **Key Vault** (Azure Key Vault) — for production
-- **Configuration** (appsettings.json) — for development only
+- **Key Vault** (Azure Key Vault) — for production and development
+- **User secrets** (`dotnet user-secrets`) — for local development (never committed to source control)
 - **Environment variables** — for containerized deployment
+
+> **Warning:** Never store secrets in `appsettings.json` or other files tracked by source control, even for development. Use `dotnet user-secrets` or environment variables instead.
 
 **As a consumer**: You don't see the keys. They're managed by the service team.
 

--- a/skills/fusion-backend-dev/references/integration-patterns.md
+++ b/skills/fusion-backend-dev/references/integration-patterns.md
@@ -162,7 +162,21 @@ if (!headerValue.StartsWith(signaturePrefix, StringComparison.Ordinal))
     return Results.Unauthorized();  // Missing or malformed signature
 }
 
-byte[] providedSignature = Convert.FromHexString(headerValue.Substring(signaturePrefix.Length));
+string providedSignatureHex = headerValue.Substring(signaturePrefix.Length);
+if (providedSignatureHex.Length != computedSignature.Length * 2)
+{
+    return Results.Unauthorized();  // Malformed signature length
+}
+
+byte[] providedSignature;
+try
+{
+    providedSignature = Convert.FromHexString(providedSignatureHex);
+}
+catch (FormatException)
+{
+    return Results.Unauthorized();  // Malformed signature encoding
+}
 
 if (!System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(computedSignature, providedSignature))
 {

--- a/skills/fusion-backend-dev/references/integration-patterns.md
+++ b/skills/fusion-backend-dev/references/integration-patterns.md
@@ -1,0 +1,276 @@
+# Cross-Service & External API Integration
+
+## Calling Other Fusion Services
+
+### Typed HTTP Client Pattern
+
+Fusion services use typed HTTP clients for service-to-service calls:
+
+```csharp
+// Backend service example structure
+public interface IPeopleApiClient
+{
+    Task<PersonDto> GetPerson(string personId);
+    Task<List<PersonDto>> SearchPeople(string query);
+    Task<bool> UserHasRole(string personId, string role);
+}
+
+// Implementation handles:
+// - Base URL configuration
+// - Authorization token acquisition
+// - Error handling and retries
+// - Timeout management
+```
+
+**What this means for consumers**: Services have well-defined contracts. When a service calls another, it's using a typed interface (type-safe, testable).
+
+### How Services Find Each Other
+
+Services discover other services via **service discovery**:
+
+```
+1. Service startup → Register with discovery service (Consul, Kubernetes)
+2. Need to call People API → Query discovery for People service URL
+3. Discovery returns → Current URL(s) for People API
+4. Service calls → People API at discovered URL
+```
+
+**Why this matters**: Services can move without breaking things. Discovery handles routing.
+
+### Authentication Between Services
+
+When Service A calls Service B:
+
+```
+1. Service A needs token for Service B
+2. Service A requests token (using its own credentials)
+3. Token returned with Service B's scope
+4. Service A includes token in call to Service B
+5. Service B validates token → Check caller service identity
+```
+
+**Different from user auth**: Service-to-service uses service principal, not user identity. As a client, you don't implement this — it happens internally.
+
+---
+
+## External API Integration
+
+When Fusion services call external systems (outside Equinor):
+
+### Pattern: HTTP Client with Retry
+
+```csharp
+// Service configuration
+{
+  "ExternalApis": {
+    "SAPSystem": {
+      "BaseUrl": "https://sap.example.com/api",
+      "RetryPolicy": "ExponentialBackoff",
+      "RetryCount": 3,
+      "TimeoutSeconds": 30
+    }
+  }
+}
+```
+
+### Pattern: API Keys & Secrets
+
+Credentials stored in:
+- **Key Vault** (Azure Key Vault) — for production
+- **Configuration** (appsettings.json) — for development only
+- **Environment variables** — for containerized deployment
+
+**As a consumer**: You don't see the keys. They're managed by the service team.
+
+### Pattern: Request Mapping
+
+```csharp
+// Fusion model
+public class PersonDto
+{
+  public string Name { get; set; }
+  public string Email { get; set; }
+}
+
+// External system model
+public class SAPPerson
+{
+  public string FULLNAME { get; set; }  // Different casing
+  public string EMAIL_ADDRESS { get; set; }
+  public string STATUS { get; set; }  // Extra field
+}
+
+// Mapper converts between formats
+var fusion = mapper.Map<PersonDto>(sapPerson);
+```
+
+---
+
+## Webhook Handling
+
+When external systems call Fusion (Fusion receives webhooks):
+
+### Webhook Registration
+
+```
+PUT /api/v1/webhooks
+{
+  "url": "https://external-system.com/fusion-updates",
+  "events": ["ContextCreated", "PositionAssigned"],
+  "secret": "webhook-secret"  // For signature validation
+}
+```
+
+### Webhook Delivery
+
+```
+POST https://external-system.com/fusion-updates
+Content-Type: application/json
+X-Fusion-Signature: sha256={hmac_signature}
+X-Fusion-Delivery-Id: {uuid}
+
+{ /* event body */ }
+```
+
+### Signature Validation
+
+The receiver validates the signature:
+
+```csharp
+// Compute signature with shared secret
+var hmac = HMAC.SHA256(secret, requestBody);
+var signature = "sha256=" + Convert.ToHexString(hmac);
+
+// Compare with header
+if (signature != request.Headers["X-Fusion-Signature"])
+{
+  // Request may be spoofed; reject it
+  return 401 Unauthorized;
+}
+```
+
+---
+
+## Resilience Patterns
+
+Services handle external API calls carefully:
+
+### Timeout Management
+
+```csharp
+// All external calls have timeouts
+var timeout = TimeSpan.FromSeconds(30);
+using var cts = new CancellationTokenSource(timeout);
+var response = await _httpClient.GetAsync(url, cts.Token);
+```
+
+**Why**: Prevents a slow external API from blocking the entire service
+
+### Circuit Breaker
+
+When external API is failing:
+
+```
+1. Initial: Requests go through
+2. Errors exceed threshold → Circuit opens
+3. Circuit open: Requests immediately fail (fast-fail)
+4. After delay: Circuit half-open → Try one request
+5. If succeeds: Circuit closes → Back to normal
+```
+
+**Result**: Service doesn't hammer a broken external API.
+
+### Fallback & Degraded Mode
+
+If external integration fails:
+
+```csharp
+try
+{
+  var sap = await _sapClient.GetPerson(personId);
+  return enriched(sap);
+}
+catch (SAPUnavailableException)
+{
+  // SAP is down; use cached data or return minimal response
+  var cached = _cache.Get(personId);
+  return cached ?? new MinimalPersonDto();
+}
+```
+
+---
+
+## When to Cache External Data
+
+### Cache Pattern
+
+```csharp
+public async Task<PersonDto> GetPerson(string id)
+{
+  var cached = _cache.Get<PersonDto>($"person:{id}");
+  if (cached != null)
+    return cached;
+  
+  var person = await _sapClient.GetPerson(id);
+  _cache.Set($"person:{id}", person, expiration: 1hour);
+  return person;
+}
+```
+
+**When to cache**:
+- Data doesn't change frequently (person profile)
+- Read volume is high
+- External API has rate limits or latency
+
+**When NOT to cache**:
+- Data must be current (real-time inventory)
+- Small read volume (caching overhead > benefit)
+- Consistency is critical
+
+---
+
+## Testing External Integration
+
+### Mock/Stub Pattern
+
+```csharp
+// Interfaces allow swapping real vs mock
+public interface IExternalApiClient
+{
+  Task<PersonDto> GetPerson(string id);
+}
+
+// Production: Real HTTP client
+public class HttpExternalApiClient : IExternalApiClient { }
+
+// Testing: Mock
+public class MockExternalApiClient : IExternalApiClient
+{
+  public Task<PersonDto> GetPerson(string id)
+  {
+    return Task.FromResult(new PersonDto { Name = "Test User" });
+  }
+}
+```
+
+### Contract Testing
+
+```
+1. External API publishes its OpenAPI/Swagger spec
+2. Your service generates tests from spec
+3. Tests verify: "If I call this endpoint with this request, I get this response"
+4. Detect breaking changes early
+```
+
+---
+
+## Common Pitfalls
+
+| Pitfall | Problem | Solution |
+| --- | --- | --- |
+| No timeout | Slow API blocks service | Always set request timeout |
+| No retry | Transient failure crashes feature | Retry transient errors (500, 503, 429) |
+| No circuit breaker | Cascade failures | Use resilience library (Polly, etc.) |
+| Exposing secrets | Security breach | Use Key Vault, not config files |
+| No caching | Rate limit hit | Cache appropriately |
+| Tight coupling | Hard to test/change | Use interfaces and dependency injection |

--- a/skills/fusion-backend-dev/references/integration-patterns.md
+++ b/skills/fusion-backend-dev/references/integration-patterns.md
@@ -59,8 +59,7 @@ When Fusion services call external systems (outside Equinor):
 
 ### Pattern: HTTP Client with Retry
 
-```csharp
-// Service configuration
+```json
 {
   "ExternalApis": {
     "SAPSystem": {

--- a/skills/fusion-backend-dev/references/integration-patterns.md
+++ b/skills/fusion-backend-dev/references/integration-patterns.md
@@ -26,16 +26,18 @@ public interface IPeopleApiClient
 
 ### How Services Find Each Other
 
-Services discover other services via **service discovery**:
+Fusion services resolve other services via **configuration and the Fusion service discovery client**:
 
 ```
-1. Service startup → Register with discovery service (Consul, Kubernetes)
-2. Need to call People API → Query discovery for People service URL
-3. Discovery returns → Current URL(s) for People API
-4. Service calls → People API at discovered URL
+1. Service startup → Load base URLs from config / Key Vault
+2. Need to call People API → Use IFusionServiceDiscovery to get the endpoint
+3. Discovery returns → Current URL for People API
+4. Service calls → People API via typed HTTP client
 ```
 
-**Why this matters**: Services can move without breaking things. Discovery handles routing.
+Base URLs are managed through Azure App Configuration and Key Vault, not runtime service registries.
+
+**Why this matters**: Services have stable, centrally managed endpoints. The typed HTTP client handles auth, retries, and timeouts.
 
 ### Authentication Between Services
 

--- a/skills/fusion-backend-dev/references/validation-patterns.md
+++ b/skills/fusion-backend-dev/references/validation-patterns.md
@@ -1,0 +1,206 @@
+# Input Validation & Error Handling
+
+## Validation Pattern
+
+Fusion services validate all input before processing. Validation happens in layers:
+
+### 1. Request-Level Validation (HTTP)
+
+```
+✓ Content-Type: application/json
+✓ Authorization header present
+✓ API version supported
+```
+
+**Errors**: `400 Bad Request`, `401 Unauthorized`, `406 Not Acceptable`
+
+### 2. Model Validation (FluentValidation)
+
+Before business logic runs, all input is validated:
+
+```csharp
+// Backend service rule example:
+"Email must be a valid format"
+"Name must be 1-200 characters"
+"StartDate must be before EndDate"
+```
+
+**Error response**:
+```json
+{
+  "code": "VALIDATION_FAILED",
+  "message": "One or more validation errors occurred",
+  "details": [
+    {
+      "field": "email",
+      "code": "INVALID_EMAIL_FORMAT",
+      "message": "Email must be a valid email address"
+    },
+    {
+      "field": "startDate",
+      "code": "INVALID_DATE_RANGE",
+      "message": "Start date must be before end date"
+    }
+  ]
+}
+```
+
+### 3. Business Logic Validation
+
+After model validation passes, business rules are checked:
+
+```csharp
+// Example rules:
+"Cannot assign position holder outside hiring period"
+"Cannot delete context with active positions"
+"Cannot modify archived context"
+```
+
+**Error response**:
+```json
+{
+  "code": "BUSINESS_RULE_VIOLATION",
+  "message": "Cannot delete context with active positions",
+  "details": {
+    "violation": "ActivePositionsExist",
+    "positions": [123, 456]  // Position IDs that must be resolved first
+  }
+}
+```
+
+---
+
+## Error Response Format
+
+All Fusion services use consistent error format:
+
+```json
+{
+  "code": "ERROR_CODE",              // Machine-readable code
+  "message": "Human readable",       // What went wrong
+  "details": {                       // Optional: additional context
+    "field": "value",
+    "reason": "explanation"
+  },
+  "timestamp": "2026-04-17T10:30:00Z",  // When it happened
+  "traceId": "uuid"                  // For support/debugging
+}
+```
+
+### Common Error Codes
+
+| Code | HTTP Status | Meaning |
+| --- | --- | --- |
+| `VALIDATION_FAILED` | 400 | Input doesn't match schema or business rules |
+| `UNAUTHORIZED` | 401 | Missing or invalid authentication token |
+| `FORBIDDEN` | 403 | Authenticated but not authorized for this action |
+| `NOT_FOUND` | 404 | Resource doesn't exist |
+| `CONFLICT` | 409 | Operation conflicts with current state (e.g., already exists) |
+| `UNPROCESSABLE_ENTITY` | 422 | Request is valid but semantically incorrect |
+| `INTERNAL_SERVER_ERROR` | 500 | Service encountered unexpected error |
+
+---
+
+## How to Handle Validation Errors
+
+### For VALIDATION_FAILED (400)
+
+1. Check the `details` array for each field error
+2. Show the user the specific error message
+3. Let them correct the input
+4. Retry the request
+
+**Frontend example**:
+```typescript
+if (response.code === 'VALIDATION_FAILED') {
+  const errors = response.details.reduce((acc, err) => {
+    acc[err.field] = err.message;
+    return acc;
+  }, {});
+  
+  // Show errors in form next to fields
+  form.setErrors(errors);
+}
+```
+
+### For BUSINESS_RULE_VIOLATION (422)
+
+Business rules are often recoverable but require additional steps:
+
+1. Parse the `details` to understand what's blocking
+2. Either:
+   - Fix the prerequisite (delete active positions first, etc.)
+   - Take an alternate action (update instead of delete)
+   - Contact someone with higher permissions
+
+**Example**:
+```json
+{
+  "code": "BUSINESS_RULE_VIOLATION",
+  "message": "Cannot delete context with active positions",
+  "details": {
+    "activePositionCount": 3,
+    "alternatives": ["archive", "move_positions_to_other_context"]
+  }
+}
+```
+
+### For CONFLICT (409)
+
+Resource already exists or state changed:
+
+1. Fetch current state
+2. Decide: overwrite (send version), merge, or error to user
+
+**Optimistic lock pattern**:
+```json
+Request: PUT /contexts/{id}
+Body: { "title": "New Title", "version": 5 }
+
+Response: 409 Conflict
+{
+  "code": "VERSION_MISMATCH",
+  "message": "Resource was modified; current version is 6",
+  "details": { "currentVersion": 6 }
+}
+```
+
+---
+
+## Retry Strategy
+
+Services support idempotent retries for transient failures:
+
+| Status | Retryable? | Strategy |
+| --- | --- | --- |
+| 400, 401, 403, 404, 422 | ❌ No | Fix the request; retrying won't help |
+| 409, 429, 503, 504 | ✅ Yes | Wait and retry (exponential backoff) |
+| 500 | ✅ Maybe | Retry once; if still fails, likely needs investigation |
+
+**Recommended backoff**:
+```
+Attempt 1: immediate
+Attempt 2: wait 100ms + random jitter
+Attempt 3: wait 200ms + random jitter
+Attempt 4: wait 400ms + random jitter
+...stop after 3-4 attempts
+```
+
+---
+
+## Testing Validation
+
+Before sending requests to production:
+
+1. **Happy path**: Valid data with all required fields
+2. **Missing required fields**: Each required field removed one at a time
+3. **Invalid formats**: 
+   - Wrong type (string instead of number)
+   - Invalid email format
+   - Date outside allowed range
+4. **Business rules**: 
+   - Conflicting values (StartDate > EndDate)
+   - Violating constraints (duplicate, out of bounds)
+   - State violations (can't transition from this state)
+
+Most Fusion services include example payloads in their Swagger/OpenAPI documentation.

--- a/skills/fusion-backend-dev/references/validation-patterns.md
+++ b/skills/fusion-backend-dev/references/validation-patterns.md
@@ -174,7 +174,8 @@ Services support idempotent retries for transient failures:
 | Status | Retryable? | Strategy |
 | --- | --- | --- |
 | 400, 401, 403, 404, 422 | ❌ No | Fix the request; retrying won't help |
-| 409, 429, 503, 504 | ✅ Yes | Wait and retry (exponential backoff) |
+| 409 | ⚠️ Depends | Do not blindly retry version/state conflicts; fetch current state, resolve the conflict, then retry only with an updated request. Use backoff only for explicitly transient conflicts |
+| 429, 503, 504 | ✅ Yes | Wait and retry (exponential backoff) |
 | 500 | ✅ Maybe | Retry once; if still fails, likely needs investigation |
 
 **Recommended backoff**:

--- a/skills/fusion-backend-dev/references/validation-patterns.md
+++ b/skills/fusion-backend-dev/references/validation-patterns.md
@@ -33,7 +33,7 @@ Before business logic runs, all input is validated:
   "status": 400,
   "error": {
     "code": "ModelValidationError",
-    "message": "Model contained 2 error",
+    "message": "Model contained 2 errors",
     "errors": [
       { "property": "email", "message": "Email must be a valid email address" },
       { "property": "startDate", "message": "Start date must be before end date" }
@@ -79,7 +79,7 @@ After model validation passes, business rules are checked:
 
 ## Error Response Format
 
-All Fusion services return errors as RFC 7807 `ProblemDetails` with Fusion-specific extensions. The envelope is always the same; what varies is the `error` extension content.
+Fusion services built on the shared infrastructure libraries return errors as RFC 7807 `ProblemDetails` with Fusion-specific extensions. The envelope is consistent across services that use this pattern; what varies is the `error` extension content. Error envelopes may differ in services that predate this convention or use custom middleware.
 
 ### Validation errors (400)
 
@@ -92,7 +92,7 @@ FluentValidation failures produce a `ProblemDetails` with both a legacy `error` 
   "status": 400,
   "error": {
     "code": "ModelValidationError",
-    "message": "Model contained 2 error",
+    "message": "Model contained 2 errors",
     "errors": [
       { "property": "email", "message": "Email must be a valid email address", "attemptedValue": "bad" },
       { "property": "startDate", "message": "Must be before end date" }

--- a/skills/fusion-backend-dev/references/validation-patterns.md
+++ b/skills/fusion-backend-dev/references/validation-patterns.md
@@ -222,12 +222,13 @@ Resource already exists or state changed:
 2. Decide: overwrite (send version), merge, or error to user
 
 **Optimistic lock pattern**:
-```json
+```text
 Request: PUT /contexts/{id}
 Headers: { "If-Match": "\"etag-value\"" }
 Body: { "title": "New Title" }
+```
 
-Response: 409 Conflict
+```json
 {
   "type": "https://tools.ietf.org/html/rfc7231#section-6.5.8",
   "title": "Resource version does not match",

--- a/skills/fusion-backend-dev/references/validation-patterns.md
+++ b/skills/fusion-backend-dev/references/validation-patterns.md
@@ -18,11 +18,11 @@ Fusion services validate all input before processing. Validation happens in laye
 
 Before business logic runs, all input is validated:
 
-```csharp
-// Backend service rule example:
-"Email must be a valid format"
-"Name must be 1-200 characters"
-"StartDate must be before EndDate"
+```text
+// Backend service validation rules:
+Email must be a valid format
+Name must be 1-200 characters
+StartDate must be before EndDate
 ```
 
 **Error response** (ProblemDetails with validation extensions):
@@ -52,11 +52,11 @@ Before business logic runs, all input is validated:
 
 After model validation passes, business rules are checked:
 
-```csharp
-// Example rules:
-"Cannot assign position holder outside hiring period"
-"Cannot delete context with active positions"
-"Cannot modify archived context"
+```text
+// Example business rules:
+Cannot assign position holder outside hiring period
+Cannot delete context with active positions
+Cannot modify archived context
 ```
 
 **Error response** (via `FusionApiError.InvalidOperation` or thrown as domain exception):

--- a/skills/fusion-backend-dev/references/validation-patterns.md
+++ b/skills/fusion-backend-dev/references/validation-patterns.md
@@ -246,14 +246,18 @@ Body: { "title": "New Title" }
 
 ## Retry Strategy
 
-Services support idempotent retries for transient failures:
+Retries are only safe for operations that can be repeated without side effects:
+- Inherently idempotent methods (`GET`, `HEAD`)
+- Write operations protected by an idempotency key, `ETag`/`If-Match`, or explicit deduplication
+
+Avoid automatic retries for non-idempotent writes (e.g. `POST`/command operations) unless the API contract explicitly guarantees safe retry.
 
 | Status | Retryable? | Strategy |
 | --- | --- | --- |
 | 400, 401, 403, 404, 422 | ❌ No | Fix the request; retrying won't help |
 | 409 | ⚠️ Depends | Do not blindly retry version/state conflicts; fetch current state, resolve the conflict, then retry only with an updated request. Use backoff only for explicitly transient conflicts |
-| 429, 503, 504 | ✅ Yes | Wait and retry (exponential backoff) |
-| 500 | ✅ Maybe | Retry once; if still fails, likely needs investigation |
+| 429, 503, 504 | ✅ Conditional | Retry with exponential backoff only for idempotent or deduplication-protected requests |
+| 500 | ✅ Conditional | Retry once only if the operation is idempotent or protected; if it still fails, investigate |
 
 **Recommended backoff**:
 ```

--- a/skills/fusion-backend-dev/references/validation-patterns.md
+++ b/skills/fusion-backend-dev/references/validation-patterns.md
@@ -137,7 +137,7 @@ Controllers typically produce these via `FusionApiError` static factory methods.
 - `FusionApiError.FailedDependency(code, message)` → 424
 - `FusionApiError.IncorrectETag(message)` → 409
 
-> **Note:** Exact method signatures may vary across service versions. Verify available factory methods in the target service's source or via MCP `search_backend_code`.
+> **Note:** Exact method signatures may vary across service versions. Verify available factory methods in the target service's source or via MCP `mcp_fusion_search_backend_code`.
 
 ### Unhandled exceptions (500, middleware-caught)
 

--- a/skills/fusion-backend-dev/references/validation-patterns.md
+++ b/skills/fusion-backend-dev/references/validation-patterns.md
@@ -129,7 +129,7 @@ Domain-specific errors use the same `ProblemDetails` envelope with an `error` ex
 }
 ```
 
-Controllers produce these via `FusionApiError` static factory methods (defined in `fusion-libraries`):
+Controllers typically produce these via `FusionApiError` static factory methods. The following are common patterns observed in fusion-libraries (`Fusion.AspNetCore` namespace) and fusion-core-services controllers:
 - `FusionApiError.NotFound(resource, message)` → 404
 - `FusionApiError.InvalidOperation(code, message)` → 400
 - `FusionApiError.ResourceExists(resource, message, exception)` → 409
@@ -137,15 +137,17 @@ Controllers produce these via `FusionApiError` static factory methods (defined i
 - `FusionApiError.FailedDependency(code, message)` → 424
 - `FusionApiError.IncorrectETag(message)` → 409
 
+> **Note:** Exact method signatures may vary across service versions. Verify available factory methods in the target service's source or via MCP `search_backend_code`.
+
 ### Unhandled exceptions (500, middleware-caught)
 
-The `ApiExceptionMiddleware` catches unhandled exceptions and maps known types:
+Services commonly use an exception middleware (e.g. `ApiExceptionMiddleware`) that catches unhandled exceptions and maps known types to HTTP status codes. Typical mappings include:
 - `NotFoundError` → 404
-- `NotAuthorizedError` → 403 (includes `accessRequirements` in the error)
+- `NotAuthorizedError` → 403 (may include `accessRequirements` in the error)
 - `ResourceExistsError` → 409
 - `ReadOnlyModeError` → 500 with read-only context
 
-Stack traces are included only in development/test environments.
+> These exception types and mappings are illustrative of the pattern used in fusion-libraries and fusion-core-services. Not all services implement every mapping — check the target service's middleware configuration.
 
 ### Common Error Codes
 

--- a/skills/fusion-backend-dev/references/validation-patterns.md
+++ b/skills/fusion-backend-dev/references/validation-patterns.md
@@ -12,7 +12,7 @@ Fusion services validate all input before processing. Validation happens in laye
 ✓ API version supported
 ```
 
-**Errors**: `400 Bad Request`, `401 Unauthorized`, `406 Not Acceptable`
+**Errors**: `400 Bad Request`, `401 Unauthorized`, `415 Unsupported Media Type`
 
 ### 2. Model Validation (FluentValidation)
 
@@ -25,23 +25,26 @@ Before business logic runs, all input is validated:
 "StartDate must be before EndDate"
 ```
 
-**Error response**:
+**Error response** (ProblemDetails with validation extensions):
 ```json
 {
-  "code": "VALIDATION_FAILED",
-  "message": "One or more validation errors occurred",
-  "details": [
-    {
-      "field": "email",
-      "code": "INVALID_EMAIL_FORMAT",
-      "message": "Email must be a valid email address"
-    },
-    {
-      "field": "startDate",
-      "code": "INVALID_DATE_RANGE",
-      "message": "Start date must be before end date"
-    }
-  ]
+  "type": "https://tools.ietf.org/html/rfc7231#section-6.5.1",
+  "title": "One or more validation errors occurred.",
+  "status": 400,
+  "error": {
+    "code": "ModelValidationError",
+    "message": "Model contained 2 error",
+    "errors": [
+      { "property": "email", "message": "Email must be a valid email address" },
+      { "property": "startDate", "message": "Start date must be before end date" }
+    ]
+  },
+  "errors": {
+    "email": ["Email must be a valid email address"],
+    "startDate": ["Start date must be before end date"]
+  },
+  "traceId": "...",
+  "timestamp": "..."
 }
 ```
 
@@ -56,15 +59,19 @@ After model validation passes, business rules are checked:
 "Cannot modify archived context"
 ```
 
-**Error response**:
+**Error response** (via `FusionApiError.InvalidOperation` or thrown as domain exception):
 ```json
 {
-  "code": "BUSINESS_RULE_VIOLATION",
-  "message": "Cannot delete context with active positions",
-  "details": {
-    "violation": "ActivePositionsExist",
-    "positions": [123, 456]  // Position IDs that must be resolved first
-  }
+  "type": "https://tools.ietf.org/html/rfc7231#section-6.5.1",
+  "title": "Invalid operation",
+  "status": 400,
+  "detail": "Cannot delete context with active positions",
+  "error": {
+    "code": "InvalidOperation",
+    "message": "Cannot delete context with active positions"
+  },
+  "traceId": "...",
+  "timestamp": "..."
 }
 ```
 
@@ -72,80 +79,140 @@ After model validation passes, business rules are checked:
 
 ## Error Response Format
 
-All Fusion services use consistent error format:
+All Fusion services return errors as RFC 7807 `ProblemDetails` with Fusion-specific extensions. The envelope is always the same; what varies is the `error` extension content.
+
+### Validation errors (400)
+
+FluentValidation failures produce a `ProblemDetails` with both a legacy `error` object and a standard `errors` dictionary:
 
 ```json
 {
-  "code": "ERROR_CODE",              // Machine-readable code
-  "message": "Human readable",       // What went wrong
-  "details": {                       // Optional: additional context
-    "field": "value",
-    "reason": "explanation"
+  "type": "https://tools.ietf.org/html/rfc7231#section-6.5.1",
+  "title": "One or more validation errors occurred.",
+  "status": 400,
+  "error": {
+    "code": "ModelValidationError",
+    "message": "Model contained 2 error",
+    "errors": [
+      { "property": "email", "message": "Email must be a valid email address", "attemptedValue": "bad" },
+      { "property": "startDate", "message": "Must be before end date" }
+    ]
   },
-  "timestamp": "2026-04-17T10:30:00Z",  // When it happened
-  "traceId": "uuid"                  // For support/debugging
+  "errors": {
+    "email": ["Email must be a valid email address"],
+    "startDate": ["Must be before end date"]
+  },
+  "traceId": "00-abc123...",
+  "timestamp": "2026-04-17T10:30:00Z"
 }
 ```
+
+> **Note:** The top-level `errors` dictionary (field name → message array) matches the standard ASP.NET Core validation format. The nested `error.errors` array is a legacy format with additional context like `attemptedValue`. Consumers should prefer the top-level `errors` dictionary.
+
+### Domain and operational errors (404, 409, 424, etc.)
+
+Domain-specific errors use the same `ProblemDetails` envelope with an `error` extension:
+
+```json
+{
+  "type": "https://tools.ietf.org/html/rfc7231#section-6.5.4",
+  "title": "Resource not found",
+  "status": 404,
+  "instance": "abc-123",
+  "error": {
+    "code": "ResourceNotFound",
+    "message": "Context abc-123 was not found",
+    "resourceIdentifier": "abc-123"
+  },
+  "traceId": "00-abc123...",
+  "timestamp": "2026-04-17T10:30:00Z"
+}
+```
+
+Controllers produce these via `FusionApiError` static factory methods (defined in `fusion-libraries`):
+- `FusionApiError.NotFound(resource, message)` → 404
+- `FusionApiError.InvalidOperation(code, message)` → 400
+- `FusionApiError.ResourceExists(resource, message, exception)` → 409
+- `FusionApiError.Forbidden(message)` → 403
+- `FusionApiError.FailedDependency(code, message)` → 424
+- `FusionApiError.IncorrectETag(message)` → 409
+
+### Unhandled exceptions (500, middleware-caught)
+
+The `ApiExceptionMiddleware` catches unhandled exceptions and maps known types:
+- `NotFoundError` → 404
+- `NotAuthorizedError` → 403 (includes `accessRequirements` in the error)
+- `ResourceExistsError` → 409
+- `ReadOnlyModeError` → 500 with read-only context
+
+Stack traces are included only in development/test environments.
 
 ### Common Error Codes
 
 | Code | HTTP Status | Meaning |
 | --- | --- | --- |
-| `VALIDATION_FAILED` | 400 | Input doesn't match schema or business rules |
-| `UNAUTHORIZED` | 401 | Missing or invalid authentication token |
-| `FORBIDDEN` | 403 | Authenticated but not authorized for this action |
-| `NOT_FOUND` | 404 | Resource doesn't exist |
-| `CONFLICT` | 409 | Operation conflicts with current state (e.g., already exists) |
-| `UNPROCESSABLE_ENTITY` | 422 | Request is valid but semantically incorrect |
-| `INTERNAL_SERVER_ERROR` | 500 | Service encountered unexpected error |
+| `ModelValidationError` | 400 | Input doesn't match schema or FluentValidation rules |
+| `ResourceNotFound` | 404 | Resource doesn't exist |
+| `InvalidOperation` | 400 | Business logic constraint violated |
+| `ResourceExists` / exception type | 409 | Resource already exists |
+| `NotAuthorized` | 403 | Not authorized for action |
+| `FailedDependency` | 424 | Downstream service error |
+| `Gone` | 410 | Resource has been removed |
+| `NotImplemented` | 501 | Endpoint not yet implemented |
 
 ---
 
-## How to Handle Validation Errors
+## How to Handle Error Responses
 
-### For VALIDATION_FAILED (400)
+### For Validation Errors (400)
 
-1. Check the `details` array for each field error
+1. Check the `errors` dictionary for field-level messages
 2. Show the user the specific error message
 3. Let them correct the input
 4. Retry the request
 
 **Frontend example**:
 ```typescript
-if (response.code === 'VALIDATION_FAILED') {
-  const errors = response.details.reduce((acc, err) => {
-    acc[err.field] = err.message;
-    return acc;
-  }, {});
+if (response.status === 400) {
+  const body = await response.json();
+  // body.errors is a Record<string, string[]>
+  const fieldErrors: Record<string, string> = {};
+  for (const [field, messages] of Object.entries(body.errors)) {
+    fieldErrors[field] = (messages as string[])[0];
+  }
   
   // Show errors in form next to fields
-  form.setErrors(errors);
+  form.setErrors(fieldErrors);
 }
 ```
 
-### For BUSINESS_RULE_VIOLATION (422)
+### For Business Rule Violations (400)
 
 Business rules are often recoverable but require additional steps:
 
-1. Parse the `details` to understand what's blocking
+1. Parse `error.code` and `error.message` from the ProblemDetails response
 2. Either:
    - Fix the prerequisite (delete active positions first, etc.)
    - Take an alternate action (update instead of delete)
    - Contact someone with higher permissions
 
-**Example**:
+**Example** (returned via `FusionApiError.InvalidOperation`):
 ```json
 {
-  "code": "BUSINESS_RULE_VIOLATION",
-  "message": "Cannot delete context with active positions",
-  "details": {
-    "activePositionCount": 3,
-    "alternatives": ["archive", "move_positions_to_other_context"]
-  }
+  "type": "https://tools.ietf.org/html/rfc7231#section-6.5.1",
+  "title": "Invalid operation",
+  "status": 400,
+  "detail": "Cannot delete context with active positions",
+  "error": {
+    "code": "InvalidOperation",
+    "message": "Cannot delete context with active positions"
+  },
+  "traceId": "...",
+  "timestamp": "..."
 }
 ```
 
-### For CONFLICT (409)
+### For Conflict (409)
 
 Resource already exists or state changed:
 
@@ -155,13 +222,20 @@ Resource already exists or state changed:
 **Optimistic lock pattern**:
 ```json
 Request: PUT /contexts/{id}
-Body: { "title": "New Title", "version": 5 }
+Headers: { "If-Match": "\"etag-value\"" }
+Body: { "title": "New Title" }
 
 Response: 409 Conflict
 {
-  "code": "VERSION_MISMATCH",
-  "message": "Resource was modified; current version is 6",
-  "details": { "currentVersion": 6 }
+  "type": "https://tools.ietf.org/html/rfc7231#section-6.5.8",
+  "title": "Resource version does not match",
+  "status": 409,
+  "error": {
+    "code": "IncorrectETag",
+    "message": "ETag did not match, the resource might have been updated. Refresh and try again."
+  },
+  "traceId": "...",
+  "timestamp": "..."
 }
 ```
 


### PR DESCRIPTION
## Why

Frontend developers, integrators, and architects consuming Fusion backend services lack a shared, installable skill that explains API contracts, async patterns, authorization, validation, CQRS conventions, and cross-service integration from a consumer's perspective. This PR adds the `fusion-backend-dev` skill to fill that gap.

## Current behavior

No consumer-facing skill exists for understanding Fusion backend APIs. Developers must read scattered source code and service-specific documentation to learn integration patterns.

## New behavior

A new `fusion-backend-dev` skill in `skills/fusion-backend-dev/` provides:

- **SKILL.md** — activation guidance, scope, and safety boundaries
- **references/api-contracts.md** — versioning strategy (query/header-based via `Asp.Versioning`), endpoint conventions, People/LineOrg/Context contract examples, pagination, rate limiting
- **references/async-patterns.md** — CloudEvents v1.0, Service Bus subscriptions via PUT + SAS token, event processing with `ServiceBusProcessor`
- **references/authorization-patterns.md** — Azure AD auth, delegated vs app-only tokens, RBAC, FusionApiController authorization helpers
- **references/validation-patterns.md** — FluentValidation, MediatR pipeline, ProblemDetails error format, retry guidance
- **references/cqrs-reference.md** — MediatR commands/queries, nested handlers, domain events, pipeline behaviors
- **references/integration-patterns.md** — typed HTTP clients, config-based service discovery, webhook handling (CommonLib pattern), resilience patterns
- **assets/follow-up-questions.md** — clarifying questions for ambiguous consumer requests

All examples are clearly labeled as illustrative where they don't come directly from the codebase. Endpoint URLs, response shapes, and version negotiation patterns have been verified against the real Fusion service controllers via MCP search and workspace code inspection.

## References

- Issue(s): —
- Related PR(s): equinor/fusion-core-services#2040 (fusion-services-develop skill)
- Docs / specs: —

## Reviewer focus

- Start here (files/areas): `skills/fusion-backend-dev/SKILL.md`, then the `references/` files
- Verify these behavior changes: New skill only — no existing code changed
- Risky or security-sensitive parts: References include illustrative auth patterns — verify they don't leak real App ID URIs or secrets (they use placeholders like `{resource-app-id}`)

## Self review checklist

- [x] I scoped this PR to one clear purpose.
- [x] I followed [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I did not include secrets, credentials, or sensitive data.
- [x] I reviewed my own diff for clarity and unintended changes.

## Validation

```
bun run validate:skills  ✅ (21 skills found, count check passed)
bun run biome:check      ✅ (105 files checked, no fixes needed)
```
