### PR TITLE
feat(fusion-mcp): update skill for equinor/fusion-mcp production server

### DIFF
--- a/skills/.experimental/fusion-mcp/SKILL.md
+++ b/skills/.experimental/fusion-mcp/SKILL.md
@@ -59,7 +59,7 @@ If details are missing, ask concise follow-up questions first.
    - no Docker, no API keys, no local clone needed
    - VS Code authenticates via Microsoft Entra (Equinor account)
    - use the one-click install link for prod (see `references/vscode-mcp-config.md`)
-   - or manual config with `"type": "http"` and `oauth.clientId` (see `references/vscode-mcp-config.md`)
+   - or manual config with `"type": "http"` and the server URL (see `references/vscode-mcp-config.md`)
    - do not suggest local Docker, GHCR, or self-hosted alternatives unless the user has an explicit operational need
 3. Describe the authentication flow:
    - on first tool invocation VS Code prompts the user to sign in with their Equinor Entra account

--- a/skills/.experimental/fusion-mcp/references/vscode-mcp-config.md
+++ b/skills/.experimental/fusion-mcp/references/vscode-mcp-config.md
@@ -14,7 +14,7 @@ No Docker, no API keys, no local clone required.
 
 Click the link below to add Fusion MCP to your VS Code configuration:
 
-**[Install Fusion MCP (Prod)](vscode:mcp/install?%7B%22name%22%3A%22fusion-mcp%22%2C%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.api.fusion.equinor.com%2Fmcp%22%2C%22oauth%22%3A%7B%22clientId%22%3A%22fe06d016-0e42-452e-a3d7-f08325037122%22%7D%7D)**
+**[Install Fusion MCP (Prod)](vscode:mcp/install?%7B%22name%22%3A%22fusion-mcp%22%2C%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.api.fusion.equinor.com%2Fmcp%22%7D)**
 
 ## Manual setup
 
@@ -25,10 +25,7 @@ Open the VS Code Command Palette and run **MCP: Open User Configuration**, then 
   "servers": {
     "fusion-mcp": {
       "type": "http",
-      "url": "https://mcp.api.fusion.equinor.com/mcp",
-      "oauth": {
-        "clientId": "fe06d016-0e42-452e-a3d7-f08325037122"
-      }
+      "url": "https://mcp.api.fusion.equinor.com/mcp"
     }
   }
 }
@@ -51,7 +48,7 @@ Open the VS Code Command Palette and run **MCP: Open User Configuration**, then 
 
 ## Troubleshooting quick map
 
-- Sign-in prompt not appearing: verify `oauth.clientId` in config and that VS Code is signed in with an Equinor account.
+- Sign-in prompt not appearing: verify the `fusion-mcp` server entry is enabled in VS Code MCP settings and that you are signed in with an Equinor account.
 - `401 Unauthorized`: re-authenticate via VS Code account settings; ensure your Equinor Entra account is active.
 - `tools/list` returns empty: verify the `fusion-mcp` server entry is enabled in VS Code MCP settings and reload the MCP server.
 - Partial tool behavior: check VS Code Output > Copilot for error details and restart the MCP server.


### PR DESCRIPTION
## Why

The `fusion-mcp` skill was authored against the old `equinor/fusion-poc-mcp` PoC server. That server has graduated to a production-grade hosted service (`equinor/fusion-mcp`) with a managed HTTPS endpoint, OAuth-based auth via Microsoft Entra, and an updated tool surface. The skill content was outdated and was directing users toward Docker/API key setups that no longer apply.

## Current behavior

- Skill references `equinor/fusion-poc-mcp` and `ghcr.io/equinor/fusion-poc-mcp`
- Setup guidance requires Docker, GHCR auth, and API keys (`AzureSearch__*`, `Foundry__*`)
- Tool inventory lists old POC tools (`search_index`, `search_indexes_describe`, `search_metadata_types`, `skills`)
- `vscode-mcp-config.md` shows a Docker `stdio` config template

## New behavior

- Skill promotes the hosted production server at `https://mcp.api.fusion.equinor.com/mcp` as the only recommended setup path
- VS Code config uses HTTP type with Microsoft Entra OAuth sign-in — no Docker, no API keys, no client ID required
- Tool inventory updated to current server surface: `search`, `search_framework`, `search_docs`, `search_backend_code`, `search_eds`, `search_indexes`
- `vscode-mcp-config.md` has one-click install link and manual OAuth config template
- `mcp-call-snippets.md` has accurate per-tool parameter tables sourced from server code
- `local-http-quickstart.md` removed (local setup not relevant for end users)
- Auth model docs updated: `FusionAi__*` + `AzureAd__*` replaces API key configuration

## References

- Issue(s): Resolves equinor/fusion-skills#149
- Related PR(s): —
- Docs / specs: https://github.com/equinor/fusion-mcp/blob/main/README.md

## Reviewer focus

- Start here: `skills/.experimental/fusion-mcp/SKILL.md` — setup path and instructions rewritten
- Verify these behavior changes: `references/vscode-mcp-config.md` OAuth config is correct; tool names in `mcp-call-snippets.md` match the server
- Risky or security-sensitive parts: None — no secrets, no destructive operations

## Validation evidence

```
bun run biome:check   — passed, no errors
bun run validate:skills  — passed
bun run validate:ownership — 29/29 passed
```

## Self review checklist

- [x] I scoped this PR to one clear purpose.
- [x] I followed [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I did not include secrets, credentials, or sensitive data.
- [x] I reviewed my own diff for clarity and unintended changes.