### PR TITLE
docs(fusion-issue-authoring): clarify sub_issue_id requires object ID, not issue number

### DIFF
--- a/.changeset/issue-authoring-sub-issue-id-docs.md
+++ b/.changeset/issue-authoring-sub-issue-id-docs.md
@@ -1,0 +1,13 @@
+---
+"fusion-issue-authoring": patch
+---
+
+Clarify sub_issue_id requires object ID, not issue number
+
+- Promote the ID vs number distinction to a prominent warning block above the example
+- Add a `gh api` command showing how to retrieve the object ID
+- Add a troubleshooting table covering 404, invalid input, and silent-failure modes
+- Clarify that `after_id`/`before_id` in reprioritize are also object IDs
+- Add sub-issue linking activation cues to SKILL.md triggers
+
+resolves equinor/fusion-skills#79

--- a/skills/fusion-issue-authoring/SKILL.md
+++ b/skills/fusion-issue-authoring/SKILL.md
@@ -40,6 +40,10 @@ Typical triggers:
 - "help me structure this work item"
 - "update this issue"
 - "maintain/clean up this issue"
+- "add this as a sub-issue"
+- "set parent issue"
+- "link this issue as a child"
+- "establish parent relationship"
 
 ## When not to use
 

--- a/skills/fusion-issue-authoring/references/mcp-server.md
+++ b/skills/fusion-issue-authoring/references/mcp-server.md
@@ -171,6 +171,22 @@ Only include `type` when issue types are supported.
 
 ### Add a sub-issue to a parent issue
 
+> **`sub_issue_id` is the GitHub object ID, NOT the issue number.**
+>
+> | Format | Example | Used in URLs / UI? |
+> |---|---|---|
+> | Issue number | `#79`, `79` | Yes |
+> | Object ID | `3969391411` | No — internal only |
+>
+> **Always retrieve the object ID before calling `sub_issue_write`.**
+>
+> ```bash
+> # Get the object ID for a sub-issue by its number
+> gh api repos/OWNER/REPO/issues/NUMBER -q '.id'
+> # Example: gh api repos/equinor/fusion-skills/issues/79 -q '.id'
+> # Output: 3969391411
+> ```
+
 ```json
 {
   "method": "add",
@@ -181,7 +197,13 @@ Only include `type` when issue types are supported.
 }
 ```
 
-Note: `sub_issue_id` is the sub-issue **ID**, not issue number.
+#### Troubleshooting sub-issue linking
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| 404 error | Used issue number instead of object ID | Run `gh api repos/OWNER/REPO/issues/NUMBER -q '.id'` to get the correct ID |
+| "Invalid input" error | `sub_issue_id` missing or wrong format | Confirm value is a numeric ID (e.g. `3969391411`), not a string or `#79` |
+| Sub-issue not added silently | Parent issue or sub-issue does not exist, or insufficient permissions | Verify both issues exist and the token has write access |
 
 ### Reprioritize sub-issues
 
@@ -196,7 +218,7 @@ Note: `sub_issue_id` is the sub-issue **ID**, not issue number.
 }
 ```
 
-Use either `after_id` or `before_id` for reprioritization.
+Use either `after_id` or `before_id` for reprioritization. Both `sub_issue_id` and `after_id`/`before_id` are object IDs, not issue numbers.
 
 ## Minimal task-batch order
 


### PR DESCRIPTION
## Why

Developers following the `fusion-issue-authoring` sub-issue linking example were making 6+ failed API calls because `sub_issue_id` requires a GitHub **object ID** (e.g. `3969391411`), not an issue number (e.g. `79`). The distinction was only a footnote after the code example, there was no way to retrieve the ID, no troubleshooting guidance, and the skill had no activation cues for sub-issue linking tasks.

## Current behavior

- The warning "sub_issue_id is the ID, not issue number" appears as a note *after* the example — easy to miss.
- No `gh api` command is shown for retrieving the object ID.
- No troubleshooting table for the common 404 / invalid-input / silent-failure modes.
- "add this as a sub-issue", "set parent issue" etc. do not appear in the skill's activation triggers, so the skill is not discoverable for linking workflows.

## New behavior

- A prominent warning block with an ID vs number comparison table appears *before* the code example.
- A `gh api repos/OWNER/REPO/issues/NUMBER -q '.id'` command shows exactly how to get the object ID.
- A troubleshooting table covers the three most common failure modes.
- The reprioritize example note clarifies `after_id`/`before_id` are also object IDs.
- Four sub-issue–linking activation cues added to `SKILL.md` triggers.

## References

- Issue(s): resolves equinor/fusion-skills#79
- Related PR(s):
- Docs / specs:

## Reviewer focus

- Start here (files/areas):
  - `skills/fusion-issue-authoring/references/mcp-server.md` — the "Add a sub-issue" section
  - `skills/fusion-issue-authoring/SKILL.md` — "Typical triggers" list
- Verify these behavior changes:
  - Warning block appears before the JSON example, not after
  - `gh api` ID-retrieval command is present and accurate
  - Troubleshooting table covers 404, invalid input, and silent failure
- Risky or security-sensitive parts:
  - Docs-only change; no runtime script changes

## Self review checklist

- [x] I scoped this PR to one clear purpose.
- [x] I followed [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I did not include secrets, credentials, or sensitive data.
- [x] I reviewed my own diff for clarity and unintended changes.