### PR TITLE
fix: strengthen devil's advocate pass for task-planning workflow

### DIFF
--- a/.changeset/strengthen-da-pass-issue-authoring.md
+++ b/.changeset/strengthen-da-pass-issue-authoring.md
@@ -9,4 +9,4 @@ Expands the devil's advocate with:
 - Extended Task concerns in moderate mode: premature decomposition, implicit cross-task contracts, and tasks that hide unresolved architecture assumptions
 - New "Task-planning context" section in interrogator mode with four targeted decision branches: premature decomposition, implicit contracts, sequencing pressure, and hidden assumptions
 
-Resolves equinor/fusion-skills#132
+resolves equinor/fusion-skills#132

--- a/.changeset/strengthen-da-pass-issue-authoring.md
+++ b/.changeset/strengthen-da-pass-issue-authoring.md
@@ -1,0 +1,12 @@
+---
+"fusion-issue-authoring": patch
+---
+
+Strengthen devil's-advocate agent for task-planning context
+
+Expands the devil's advocate with:
+- Auto-escalation to interrogator mode when a task-planning pass surfaces two or more architecture-ambiguity signals (no user trigger required)
+- Extended Task concerns in moderate mode: premature decomposition, implicit cross-task contracts, and tasks that hide unresolved architecture assumptions
+- New "Task-planning context" section in interrogator mode with four targeted decision branches: premature decomposition, implicit contracts, sequencing pressure, and hidden assumptions
+
+Resolves equinor/fusion-skills#132

--- a/.changeset/strengthen-da-pass-task-planning.md
+++ b/.changeset/strengthen-da-pass-task-planning.md
@@ -6,4 +6,4 @@ Add explicit devil's-advocate review step before task draft generation
 
 Inserts a new step 6 that inspects the proposed task set for architecture-ambiguity signals before any drafts are generated. When two or more signals are present (unresolved design decisions, implicit backend/frontend contracts, vague sequencing, contested ownership), the workflow automatically routes to interrogator mode without requiring a user trigger. In draft-only mode with unresolved ambiguities, an `⚠ Ambiguity warning` block is emitted at the top of the plan preview.
 
-Resolves equinor/fusion-skills#132
+resolves equinor/fusion-skills#132

--- a/.changeset/strengthen-da-pass-task-planning.md
+++ b/.changeset/strengthen-da-pass-task-planning.md
@@ -1,0 +1,9 @@
+---
+"fusion-issue-task-planning": patch
+---
+
+Add explicit devil's-advocate review step before task draft generation
+
+Inserts a new step 6 that inspects the proposed task set for architecture-ambiguity signals before any drafts are generated. When two or more signals are present (unresolved design decisions, implicit backend/frontend contracts, vague sequencing, contested ownership), the workflow automatically routes to interrogator mode without requiring a user trigger. In draft-only mode with unresolved ambiguities, an `⚠ Ambiguity warning` block is emitted at the top of the plan preview.
+
+Resolves equinor/fusion-skills#132

--- a/skills/.experimental/fusion-issue-task-planning/SKILL.md
+++ b/skills/.experimental/fusion-issue-task-planning/SKILL.md
@@ -87,17 +87,29 @@ Execute in order and state assumptions explicitly.
    - For each task include objective, scope boundary, deliverable, verification method, and mapped AC references.
    - Prefer independently verifiable slices.
 
-6. Generate task issue drafts
+6. Run devil's-advocate review before drafting
+   - Inspect the proposed task set for architecture-ambiguity signals:
+     - Unresolved design or architecture decisions mentioned in the story, comments, or ancestor issues
+     - Backend and frontend tasks that share an implicit API, data model, or ownership contract not yet agreed
+     - A discovery, research, or alignment task alongside concrete implementation tasks with no explicit blocking relationship
+     - Dependency statements that are vague or circular ("after backend is done", "when design is ready")
+     - Component, API, or data-model ownership that is unclear or contested
+   - If two or more signals are present, route the task set through `agents/devils-advocate.agent.md` (via `fusion-issue-authoring`) in **interrogator mode** automatically — no user trigger required.
+   - If zero or one signal is present, route in **moderate mode** and surface up to 3 concerns before continuing.
+   - Do not proceed to draft generation until either the devil's advocate confirms the split is sound or the user explicitly accepts the listed risks.
+   - In `draft-only` mode with unresolved major ambiguities: continue to draft but emit an `⚠ Ambiguity warning` block at the top of the plan preview listing the unresolved items.
+
+7. Generate task issue drafts
    - `orchestrated`: route through `fusion-issue-authoring` with issue type `Task`
    - `direct-subordinate`: invoke `fusion-issue-author-task` in draft-only mode and output explicit publish instructions that delegate final mutation to `fusion-issue-authoring`
    - `inline`: write `.tmp/TASK-<nn>-<slug>.md` drafts using the minimal built-in structure from step 1
    - Keep drafts local until explicit publish approval.
 
-7. Generate plan preview
+8. Generate plan preview
    - Write `.tmp/USER-STORY-TASK-PLAN-<context>.md` from `assets/task-plan-template.md`.
    - Include summary, traceability, ordered tasks, draft paths, publish plan, assumptions, risks.
 
-8. Publish only after explicit confirmation
+9. Publish only after explicit confirmation
    - Require explicit confirmation in the same turn.
    - Stop if unresolved assumptions remain.
    - Delegate publish execution to `fusion-issue-authoring` and prefer sub-agent invocation for task issue creation/update/linking.
@@ -108,7 +120,7 @@ Execute in order and state assumptions explicitly.
    - Do not call MCP write tools directly from this skill in publish mode.
    - Hard fail publish mode if delegated execution returns unresolved item-level failures.
 
-9. Repair mode for already-created tasks
+10. Repair mode for already-created tasks
    - If tasks were created but are missing `Issue Type` or parent linkage, delegate repair to `fusion-issue-authoring` and prefer sub-agent invocation.
    - Provide per-issue repair intent (`set type=Task`, add missing parent links, preserve order) and require verification results from the delegated run.
    - Repair mode must be idempotent: skip already-correct issues and fix only missing metadata.

--- a/skills/.experimental/fusion-issue-task-planning/SKILL.md
+++ b/skills/.experimental/fusion-issue-task-planning/SKILL.md
@@ -94,10 +94,12 @@ Execute in order and state assumptions explicitly.
      - A discovery, research, or alignment task alongside concrete implementation tasks with no explicit blocking relationship
      - Dependency statements that are vague or circular ("after backend is done", "when design is ready")
      - Component, API, or data-model ownership that is unclear or contested
-   - If two or more signals are present, route the task set through `agents/devils-advocate.agent.md` (via `fusion-issue-authoring`) in **interrogator mode** automatically — no user trigger required.
-   - If zero or one signal is present, route in **moderate mode** and surface up to 3 concerns before continuing.
-   - Do not proceed to draft generation until either the devil's advocate confirms the split is sound or the user explicitly accepts the listed risks.
-   - In `draft-only` mode with unresolved major ambiguities: continue to draft but emit an `⚠ Ambiguity warning` block at the top of the plan preview listing the unresolved items.
+   - If two or more signals are present:
+     - `orchestrated` mode: route through `fusion-issue-authoring` → `agents/devils-advocate.agent.md` in **interrogator mode** automatically — no user trigger required.
+     - `direct-subordinate` or `inline` mode: run an inline DA checklist using the same five signals above; surface findings as a structured `⚠ Ambiguity checklist` and require the user to resolve or explicitly accept each before draft generation.
+   - If zero or one signal is present, run in **moderate mode**: surface up to 3 concerns and continue after the user acknowledges.
+   - **Publish gate** (all modes): do not publish tasks until either the devil's advocate confirms the split is sound or the user explicitly accepts the listed risks.
+   - **Draft-only exception**: in `draft-only` mode, draft generation may proceed even with unresolved ambiguities, but emit an `⚠ Ambiguity warning` block at the top of the plan preview listing each unresolved item. Publication remains blocked until risks are accepted.
 
 7. Generate task issue drafts
    - `orchestrated`: route through `fusion-issue-authoring` with issue type `Task`

--- a/skills/fusion-issue-authoring/SKILL.md
+++ b/skills/fusion-issue-authoring/SKILL.md
@@ -79,7 +79,7 @@ Classify request as `Bug`, `Feature`, `User Story`, or `Task`, then activate the
 
 If ambiguous, ask only essential clarifying questions.
 
-Devil's advocate pass: `agents/devils-advocate.agent.md` is always active in moderate mode — it surfaces the 2–3 most important concerns after classification without interrupting flow. When the user asks to be "grilled", says "stress-test this", or when scope/criteria gaps are significant, escalate to interrogator mode for a full structured interview before the type-specific agent. The devil's advocate returns confirmed decisions and noted risks, then hands off to the type-specific drafting agent.
+Devil's advocate pass: `agents/devils-advocate.agent.md` is always active in moderate mode — it surfaces the 2–3 most important concerns after classification without interrupting flow. When the user asks to be "grilled", says "stress-test this", when scope/criteria gaps are significant, or when invoked from `fusion-issue-task-planning` with two or more architecture-ambiguity signals present, escalate to interrogator mode for a full structured interview before the type-specific agent. The devil's advocate returns confirmed decisions and noted risks, then hands off to the type-specific drafting agent.
 
 ### Step 2 — Resolve repository and template
 

--- a/skills/fusion-issue-authoring/SKILL.md
+++ b/skills/fusion-issue-authoring/SKILL.md
@@ -24,7 +24,7 @@ This skill uses internal agent modes for type-specific drafting logic:
 - `agents/feature.agent.md`: feature-focused scope and acceptance structure
 - `agents/user-story.agent.md`: role/workflow/scenario-driven story structure
 - `agents/task.agent.md`: checklist-first task decomposition and dependency planning
-- `agents/devils-advocate.agent.md`: always-on quality collaborator that raises key concerns after classification (moderate mode) and runs a full structured interview when explicitly asked or when scope/criteria gaps are significant (interrogator mode)
+- `agents/devils-advocate.agent.md`: always-on quality collaborator that raises key concerns after classification (moderate mode) and runs a full structured interview when explicitly asked, when scope/criteria gaps are significant, or when invoked from `fusion-issue-task-planning` with two or more architecture-ambiguity signals present (interrogator mode)
 
 Agent modes are activated internally based on issue type classification. Users never reference agent files directly. Shared gates (labels, assignee confirmation, draft review, publish confirmation, and mutation sequencing) remain in this skill.
 

--- a/skills/fusion-issue-authoring/agents/devils-advocate.agent.md
+++ b/skills/fusion-issue-authoring/agents/devils-advocate.agent.md
@@ -6,7 +6,7 @@ Always-on quality collaborator for issue authoring. Plays the opposing side to s
 
 **Moderate mode (default):** Active during normal authoring. Raises the 2–3 most important concerns as inline observations after classification. Does not interrupt flow or force a separate interview.
 
-**Interrogator mode (on request or significant gaps):** Full structured interview when the user says "grill me", "stress-test this", "poke holes", or equivalent — or when scope/criteria gaps are significant after classification — or when a task-planning pass surfaces two or more architecture-ambiguity signals (see Task-planning context below). Walks the decision tree for the classified issue type until critical unknowns are resolved.
+**Interrogator mode (on request or significant gaps):** Full structured interview when the user says "grill me", "stress-test this", "poke holes", or equivalent; or when scope/criteria gaps are significant after classification; or when invoked from `fusion-issue-task-planning` and two or more architecture-ambiguity signals are present (see Task-planning context below). Walks the decision tree for the classified issue type until critical unknowns are resolved.
 
 ## When not to use
 
@@ -56,7 +56,12 @@ When the classified type is derived from a User Story task-planning pass, priori
 - **Sequencing pressure**: Should more tasks stay blocked behind a discovery, research, or contract-alignment task? Are implementation tasks safe to start in parallel, or do they share hidden dependencies?
 - **Hidden assumptions**: Do tasks look concrete but depend on answers absent from the story, comments, or ancestor issues?
 
-Auto-escalate to interrogator mode (without user trigger) if two or more of these signals are detected after reading the User Story and its context.
+Auto-escalate to interrogator mode (without user trigger) if two or more of the following concrete signals are detected after reading the User Story and its context:
+- Unresolved design or architecture decisions mentioned in the story, comments, or ancestor issues
+- Backend and frontend tasks that share an implicit API, data model, or ownership contract not yet agreed
+- A discovery, research, or alignment task alongside concrete implementation tasks with no explicit blocking relationship
+- Dependency statements that are vague or circular ("after backend is done", "when design is ready")
+- Component, API, or data-model ownership that is unclear or contested
 
 #### Step 2: Interview — one question at a time
 

--- a/skills/fusion-issue-authoring/agents/devils-advocate.agent.md
+++ b/skills/fusion-issue-authoring/agents/devils-advocate.agent.md
@@ -6,7 +6,7 @@ Always-on quality collaborator for issue authoring. Plays the opposing side to s
 
 **Moderate mode (default):** Active during normal authoring. Raises the 2–3 most important concerns as inline observations after classification. Does not interrupt flow or force a separate interview.
 
-**Interrogator mode (on request or significant gaps):** Full structured interview when the user says "grill me", "stress-test this", "poke holes", or equivalent — or when scope/criteria gaps are significant after classification. Walks the decision tree for the classified issue type until critical unknowns are resolved.
+**Interrogator mode (on request or significant gaps):** Full structured interview when the user says "grill me", "stress-test this", "poke holes", or equivalent — or when scope/criteria gaps are significant after classification — or when a task-planning pass surfaces two or more architecture-ambiguity signals (see Task-planning context below). Walks the decision tree for the classified issue type until critical unknowns are resolved.
 
 ## When not to use
 
@@ -31,7 +31,7 @@ Weave into the authoring flow without a separate interview:
    - **Bug**: reproduction gaps, unclear severity, missing environment detail
    - **Feature**: vague scope boundaries, untestable success criteria, hidden dependencies
    - **User Story**: unclear role, incomplete scenarios, non-testable acceptance criteria
-   - **Task**: missing decomposition, circular blockers, no validation approach
+   - **Task**: missing decomposition, circular blockers, no validation approach; in a task-planning context also probe for premature decomposition (splitting implementation before design is settled), implicit cross-task contracts (backend/frontend API shape not yet agreed), and tasks that look actionable but hide unresolved architecture assumptions
 3. Resolve what you can from the codebase silently.
 4. Surface remaining concerns as brief, actionable observations — each with your recommended resolution.
 5. Let the user accept, adjust, or dismiss. Hand off to the type-specific agent.
@@ -46,6 +46,17 @@ Structured interview for thorough plan stress-testing:
 2. Identify unresolved decision branches for the classified issue type.
 3. Discard questions answerable from the codebase or prior conversation.
 4. Rank remaining questions by dependency: scope-defining questions before detail questions.
+
+#### Task-planning context (User Story decomposition)
+
+When the classified type is derived from a User Story task-planning pass, prioritize these unresolved decision branches in the interview:
+
+- **Premature decomposition**: Are we splitting implementation before critical design or architecture decisions are settled? Could the proposed split be invalidated by unresolved choices?
+- **Implicit contracts**: Do tasks assume a backend/frontend API shape, data model, or ownership boundary that is not yet agreed? Surface the assumed contracts explicitly.
+- **Sequencing pressure**: Should more tasks stay blocked behind a discovery, research, or contract-alignment task? Are implementation tasks safe to start in parallel, or do they share hidden dependencies?
+- **Hidden assumptions**: Do tasks look concrete but depend on answers absent from the story, comments, or ancestor issues?
+
+Auto-escalate to interrogator mode (without user trigger) if two or more of these signals are detected after reading the User Story and its context.
 
 #### Step 2: Interview — one question at a time
 


### PR DESCRIPTION
## Why

The task-planning workflow was too passive during its devil's-advocate pass. When planning tasks for a user story with unresolved architecture decisions, the workflow moved quickly into concrete task drafts without sufficiently challenging the decomposition — resulting in tasks that users later felt were under-challenged and sometimes premature.

Reported in equinor/fusion-skills#132.

## Current behavior

- The devil's advocate runs in moderate mode by default, raising at most 2–3 generic concerns.
- It only escalates to interrogator mode when the user explicitly asks ("grill me", "stress-test this").
- The task-planning skill (`fusion-issue-task-planning`) has no dedicated gate before draft generation.
- Task-specific concerns in moderate mode are limited to decomposition, circular blockers, and validation approach.

## New behavior

**`fusion-issue-task-planning`** — New step 6 inserted before task draft generation:
- Inspects the proposed task set for 5 concrete architecture-ambiguity signals (unresolved design decisions, implicit backend/frontend contracts, vague sequencing, contested ownership, etc.)
- Auto-escalates to interrogator mode when 2+ signals are detected — no user trigger required
- Blocks draft generation until the DA confirms the split is sound or the user explicitly accepts the listed risks
- In `draft-only` mode with unresolved ambiguities: emits an `⚠ Ambiguity warning` block at the top of the plan preview

**`fusion-issue-authoring` / `agents/devils-advocate.agent.md`**:
- Interrogator mode now auto-triggers from a task-planning context (no user prompt needed) when architecture-ambiguity signals are present
- Task concerns in moderate mode expanded: premature decomposition, implicit cross-task contracts, tasks hiding unresolved architecture assumptions
- New **Task-planning context** section in interrogator mode with four targeted decision branches: premature decomposition, implicit contracts, sequencing pressure, hidden assumptions

## References

- Issue(s): Resolves equinor/fusion-skills#132
- Related PR(s): —
- Docs / specs: —

## Reviewer focus

- Start here: `skills/.experimental/fusion-issue-task-planning/SKILL.md` step 6 (new), `skills/fusion-issue-authoring/agents/devils-advocate.agent.md`
- Verify these behavior changes: interrogator mode should now auto-trigger in task-planning context without user prompting; new ambiguity signals are concrete and actionable
- Risky or security-sensitive parts: none — no mutation paths changed

## Self review checklist

- [x] I scoped this PR to one clear purpose.
- [x] I followed [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I did not include secrets, credentials, or sensitive data.
- [x] I reviewed my own diff for clarity and unintended changes.