### PR TITLE
feat(fusion-developer-app): add person components agent and reference (#858)

### DIFF
--- a/.changeset/add-person-components-agent.md
+++ b/.changeset/add-person-components-agent.md
@@ -1,0 +1,12 @@
+---
+"fusion-developer-app": minor
+---
+
+Add person component training wheels to fusion-developer-app
+
+- Expand `references/using-fusion-react-components.md` with `PersonCard`, `PersonListItem`, and `PersonCell` (AG Grid) usage examples
+- Add a decision guide table covering all person components and their intended use cases
+- Add new `agents/person-components.md` helper agent covering component selection, the custom DOM event pattern, `PersonCell` valueGetter setup, and common pitfalls
+- Update `SKILL.md` helper agents section and Step 6 module table to reference the new agent
+
+resolves equinor/fusion-core-tasks#858

--- a/skills/fusion-developer-app/SKILL.md
+++ b/skills/fusion-developer-app/SKILL.md
@@ -162,6 +162,7 @@ Identify which module the user needs, then read only the matching reference:
 | AG Charts (standalone) | `references/using-ag-charts.md` |
 | AG Grid integrated charts | `references/using-ag-grid-charts.md` |
 | EDS + Fusion React components | `references/using-fusion-react-components.md` |
+| Person display / search / selection | `references/using-fusion-react-components.md` → `agents/person-components.md` |
 | Settings | `references/using-settings.md` |
 | Bookmarks | `references/using-bookmarks.md` |
 | Analytics | `references/using-analytics.md` |
@@ -203,6 +204,7 @@ This skill also has a companion skill, `fusion-research`, for source-backed Fusi
 - **`agents/framework.md`** — reviews Fusion Framework integration: module configuration, HTTP clients, bootstrap lifecycle, runtime config, settings, bookmarks, analytics, and hook usage. **Prefers `mcp_fusion_search_framework`** for API lookups; falls back to `mcp_fusion_search_docs` for general platform guidance. Consult when wiring up `config.ts`, `app.config.ts`, or any component that accesses framework modules.
 - **`agents/styling.md`** — reviews EDS component selection, styled-components patterns, design token usage, and accessibility. **Prefers `mcp_fusion_search_eds`** for component docs, props, and examples. Consult when building or modifying visual components.
 - **`agents/data-display.md`** — reviews data display implementation: choosing between AG Grid (tabular) and AG Charts (visual), module setup, column definitions, chart options, integrated charting, and combined grid+chart pages. **Prefers `mcp_fusion_search_framework`** for AG Grid and AG Charts package lookups and cookbook examples. Consult when building grids, charts, dashboards, or any data presentation view. Use `assets/charts-decision-matrix.md` for chart library selection guidance.
+- **`agents/person-components.md`** — guides component selection and usage for `@equinor/fusion-react-person`: `PersonAvatar`, `PersonCard`, `PersonListItem`, `PersonPicker`, `PeoplePicker`, `PeopleViewer`, and `PersonCell` (AG Grid). Covers the custom DOM event pattern, `PersonCell` valueGetter setup, and common pitfalls. Consult when adding any person display, search, or selection UI.
 - **`agents/code-quality.md`** — delegates convention checks (naming, TSDoc, TypeScript strictness, intent comments) to `fusion-code-conventions`, then aggregates findings in Fusion app context. Run on every new or modified file before finalizing.
 
 ## Safety & constraints

--- a/skills/fusion-developer-app/SKILL.md
+++ b/skills/fusion-developer-app/SKILL.md
@@ -197,7 +197,7 @@ Use `assets/review-checklist.md` as a comprehensive post-generation checklist.
 
 ## Helper agents
 
-This skill includes four optional helper agents in `agents/`. Use them for focused review after implementing changes, or consult them during implementation for specific guidance. If the runtime does not support skill-local agents, apply the same review criteria inline.
+This skill includes five optional helper agents in `agents/`. Use them for focused review after implementing changes, or consult them during implementation for specific guidance. If the runtime does not support skill-local agents, apply the same review criteria inline.
 
 This skill also has a companion skill, `fusion-research`, for source-backed Fusion ecosystem research. Use it when implementation work is blocked by uncertainty about framework behavior, EDS component APIs, or skill catalog questions.
 

--- a/skills/fusion-developer-app/agents/person-components.md
+++ b/skills/fusion-developer-app/agents/person-components.md
@@ -63,13 +63,22 @@ Refer to `references/using-fusion-react-components.md` for complete copy-pasteab
 
 Key patterns to reinforce:
 
-**Person components resolve people data automatically** — pass `azureId` (preferred) or `upn`. Do not pass name strings or fetch people data manually.
+**Display components resolve people data automatically** — `PersonAvatar`, `PersonCard`, `PersonListItem`, and `PersonCell` accept an `azureId` (preferred) or `upn` prop. Do not pass name strings or fetch people data manually.
 
-**Event pattern** — person picker/selector components fire custom DOM events, not standard React callbacks. Always access the person via `e.detail`:
+**Picker and viewer components work with `PersonInfo` objects** — `PersonPicker`, `PeoplePicker`, and `PeopleViewer` accept a `person` (`PersonInfo`) or `people` (`PersonInfo[]`) prop. Do not pass raw `azureId`/`upn` strings to these components.
+
+**Picker/selector event pattern** — person picker/selector components fire custom DOM events, not standard React callbacks. Always access the person via `e.detail`:
 ```typescript
 onPersonAdded={(e: PersonAddedEvent) => {
   const person: PersonInfo = e.detail;
 }}
+```
+
+**`person-click` DOM event** — display components (`PersonCard`, `PersonListItem`, `PersonCell`) fire a `person-click` custom DOM event when the user clicks the person element. Access the clicked person via `e.detail`:
+```typescript
+element.addEventListener('person-click', (e: PersonClickEvent) => {
+  const person: PersonInfo = e.detail;
+});
 ```
 
 **`PersonCell` in AG Grid** — the cell renderer reads the cell value as an `azureId` string. If the `azureId` is nested, use `valueGetter` to extract it:

--- a/skills/fusion-developer-app/agents/person-components.md
+++ b/skills/fusion-developer-app/agents/person-components.md
@@ -1,0 +1,94 @@
+# Person Components Agent
+
+## Role
+
+Use this helper agent when a developer asks how to display, search, pick, or list people in a Fusion Framework app using `@equinor/fusion-react-person`. It covers component selection, usage patterns, `PersonCell` in AG Grid, common pitfalls, and the correct import paths.
+
+Delegate token-level EDS styling questions to `agents/styling.md`. Delegate AG Grid module setup questions to `agents/data-display.md`.
+
+## Inputs
+
+- `question`: what the developer is trying to build (e.g. "show a person avatar", "ag-grid column with person names", "multi-person picker")
+- `file_paths` (optional): source files already in the project to review for existing patterns
+
+## MCP tooling
+
+When Fusion MCP is available, use **`mcp_fusion_search_eds`** for EDS component props and **`mcp_fusion_search_framework`** for framework integration questions. Cross-check against the [fusion-react-components Storybook](https://equinor.github.io/fusion-react-components/?path=/docs/person-docs--docs) when component behaviour is unclear.
+
+## Process
+
+### Step 1: Identify the UI need
+
+Map the developer's request to a component using the decision guide:
+
+| UI need | Component |
+|---|---|
+| Avatar only, hover for details | `PersonAvatar` |
+| Full detail view (card, panel, popover) | `PersonCard` |
+| One-line person row in a list | `PersonListItem` |
+| Person row with action button (remove, edit) | `PersonListItem` with children |
+| Pick a single person | `PersonPicker` or `PersonSelect` |
+| Pick multiple people | `PeoplePicker` |
+| Display a selected collection | `PeopleViewer` |
+| AG Grid cell | `PersonCell` |
+
+If the need is still ambiguous after reading the request, ask: _"Are you looking to display a person's info, let the user pick a person, or show people in a data grid?"_
+
+### Step 2: Confirm import paths
+
+All person components are imported from `@equinor/fusion-react-person`:
+
+```typescript
+import {
+  PersonAvatar,
+  PersonCard,
+  PersonListItem,
+  PersonPicker,
+  PersonSelect,
+  PeoplePicker,
+  PeopleViewer,
+  PersonCell,
+} from '@equinor/fusion-react-person';
+
+import type {
+  PersonInfo,
+  PersonAddedEvent,
+  PersonRemovedEvent,
+} from '@equinor/fusion-react-person';
+```
+
+### Step 3: Apply the usage example
+
+Refer to `references/using-fusion-react-components.md` for complete copy-pasteable examples for each component.
+
+Key patterns to reinforce:
+
+**Person components resolve people data automatically** — pass `azureId` (preferred) or `upn`. Do not pass name strings or fetch people data manually.
+
+**Event pattern** — person picker/selector components fire custom DOM events, not standard React callbacks. Always access the person via `e.detail`:
+```typescript
+onPersonAdded={(e: PersonAddedEvent) => {
+  const person: PersonInfo = e.detail;
+}}
+```
+
+**`PersonCell` in AG Grid** — the cell renderer reads the cell value as an `azureId` string. If the `azureId` is nested, use `valueGetter` to extract it:
+```typescript
+{ cellRenderer: PersonCell, valueGetter: ({ data }) => data?.owner?.azureId }
+```
+
+### Step 4: Check for common pitfalls
+
+- **Fetching person data manually**: unnecessary — all components resolve from the Fusion People API by `azureId`. Remove any manual fetch + state pattern.
+- **Using `onPersonAdded` as a plain function callback**: wrong — it is a DOM event handler. Access the person via `e.detail`, not the argument directly.
+- **Passing a name string as `azureId`**: will silently fail. Ensure the value is a valid Azure AD object ID (UUID format).
+- **`PersonCell` receives an object instead of a string**: use `valueGetter` to extract the `azureId` before passing to the renderer.
+- **Using `PeopleViewer` without `PeoplePicker`**: `PeopleViewer` only displays — it does not manage selection state. Pair with `PeoplePicker` when selection is also needed.
+
+### Step 5: Report
+
+Produce:
+- **Component chosen** with one-line rationale
+- **Usage snippet** (copy-pasteable)
+- **Pitfalls found** (if reviewing existing code)
+- **References**: `references/using-fusion-react-components.md`, [Storybook docs](https://equinor.github.io/fusion-react-components/?path=/docs/person-docs--docs)

--- a/skills/fusion-developer-app/references/using-fusion-react-components.md
+++ b/skills/fusion-developer-app/references/using-fusion-react-components.md
@@ -156,6 +156,98 @@ Person components use **custom DOM events**, not standard React callback signatu
 />
 ```
 
+#### Display a person card
+
+`PersonCard` renders full person details — name, department, positions, active tasks, and manager — resolved automatically from the Fusion People API by `azureId`.
+
+```typescript
+import { PersonCard } from '@equinor/fusion-react-person';
+
+const OwnerCard = ({ azureId }: { azureId: string }) => (
+  <PersonCard azureId={azureId} />
+);
+```
+
+Use `PersonCard` wherever you need a full-detail person view (e.g. a details panel or a hover popover). Prefer `PersonAvatar` for compact inline display.
+
+#### Display a person list item
+
+`PersonListItem` renders a compact single-row person entry suited for lists. Action buttons are optional children.
+
+```typescript
+import { PersonListItem } from '@equinor/fusion-react-person';
+import { Button } from '@equinor/eds-core-react';
+
+// Display only
+const AssigneeRow = ({ azureId }: { azureId: string }) => (
+  <PersonListItem azureId={azureId} />
+);
+
+// With an action button
+const ReviewerRow = ({
+  azureId,
+  onRemove,
+}: {
+  azureId: string;
+  onRemove: () => void;
+}) => (
+  <PersonListItem azureId={azureId}>
+    <Button variant="ghost_icon" onClick={onRemove}>
+      Remove
+    </Button>
+  </PersonListItem>
+);
+```
+
+#### Person column in an AG Grid (PersonCell)
+
+`PersonCell` is an AG Grid cell renderer from `@equinor/fusion-react-person`. It renders an inline avatar + name row inside a grid column. The cell value must be an `azureId` string.
+
+```typescript
+import { PersonCell } from '@equinor/fusion-react-person';
+import type { ColDef } from '@equinor/fusion-framework-react-ag-grid/community';
+
+interface WorkItem {
+  id: string;
+  title: string;
+  ownerAzureId: string;
+}
+
+const columnDefs: ColDef<WorkItem>[] = [
+  { field: 'title', headerName: 'Title', flex: 2 },
+  {
+    field: 'ownerAzureId',
+    headerName: 'Owner',
+    width: 200,
+    cellRenderer: PersonCell,
+  },
+];
+```
+
+If the `azureId` is nested inside the row object, use `valueGetter` to extract it:
+
+```typescript
+{
+  headerName: 'Owner',
+  width: 200,
+  cellRenderer: PersonCell,
+  valueGetter: ({ data }) => data?.owner?.azureId,
+}
+```
+
+### Decision guide: which person component?
+
+| UI need | Component |
+|---|---|
+| Compact inline display (avatar only, hover for details) | `PersonAvatar` |
+| Full person detail view (card, panel, popover) | `PersonCard` |
+| One-line person row in a list | `PersonListItem` |
+| Person row with action buttons | `PersonListItem` with children |
+| Pick a single person | `PersonPicker` or `PersonSelect` |
+| Pick multiple people | `PeoplePicker` |
+| Display a selected set of people | `PeopleViewer` |
+| Person column in an AG Grid | `PersonCell` |
+
 ## Decision guide: EDS vs Fusion React
 
 | Need | Use |


### PR DESCRIPTION
## Why

The `fusion-developer-app` skill lacks a focused reference for Fusion's person component ecosystem (`PersonCard`, `PersonListItem`, `PersonCell`, `PersonPicker`, `PeoplePicker`). Developers currently have no in-skill guidance for component selection, the DOM event pattern, or using `PersonCell` in AG Grid.

## Current behavior

No person-component coverage in `fusion-developer-app`. Developers must search the Fusion Framework docs or guess which component to use.

## New behavior

- `references/using-fusion-react-components.md` expanded with `PersonCard`, `PersonListItem`, `PersonCell` (AG Grid), and a component selection guide table.
- New helper agent `agents/person-components.md` covers component selection, the `person-click` DOM event pattern, `PersonCell` valueGetter, and common pitfalls.
- `SKILL.md` updated with person-display activation triggers and a new row in the Step 6 module table.

## References

- Issue(s): Resolves equinor/fusion-core-tasks#858
- Related PR(s): —
- Docs / specs: [Fusion React Components](https://equinor.github.io/fusion-framework/)

## Reviewer focus

- Start here: `skills/fusion-developer-app/agents/person-components.md`, `skills/fusion-developer-app/references/using-fusion-react-components.md`
- Verify these behavior changes: component selection table covers all person components, DOM event pattern is correct, `PersonCell` AG Grid example compiles
- Risky or security-sensitive parts: none

## Self review checklist

- [x] I scoped this PR to one clear purpose.
- [x] I followed [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I did not include secrets, credentials, or sensitive data.
- [x] I reviewed my own diff for clarity and unintended changes.
