### PR TITLE
feat: add equinor-design-system subordinate system skill (#859)

### DIFF
--- a/.changeset/add-equinor-design-system-skill.md
+++ b/.changeset/add-equinor-design-system-skill.md
@@ -7,9 +7,9 @@ Add equinor-design-system system skill
 New `.system` subordinate skill encoding authoritative EDS design rules for agents:
 - Color tokens (interactive, semantic, text, surface) with brand constraints
 - Typography variant hierarchy and usage rules
-- Spacing token reference (`--eds-space-*`)
-- Elevation and shadow tokens
-- Icon usage rules via `@equinor/eds-icons` + `Icon`
+- Spacing token reference (`--eds-spacing-horizontal-<size>` / `--eds-spacing-vertical-<size>`)
+- Elevation: no CSS vars in EDS v2; guidance to use `Paper` component or JS token import
+- Icon usage rules via `@equinor/eds-icons` + `<Icon data={...} />` (accessibility: `title` required)
 - Fusion Portal three-zone page layout conventions, empty/loading state patterns
 
 Consumed by other skills and agents as a ground-truth lookup reference, not as a standalone workflow.

--- a/.changeset/add-equinor-design-system-skill.md
+++ b/.changeset/add-equinor-design-system-skill.md
@@ -1,0 +1,17 @@
+---
+"equinor-design-system": minor
+---
+
+Add equinor-design-system system skill
+
+New `.system` subordinate skill encoding authoritative EDS design rules for agents:
+- Color tokens (interactive, semantic, text, surface) with brand constraints
+- Typography variant hierarchy and usage rules
+- Spacing token reference (`--eds-space-*`)
+- Elevation and shadow tokens
+- Icon usage rules via `@equinor/eds-icons` + `Icon`
+- Fusion Portal three-zone page layout conventions, empty/loading state patterns
+
+Consumed by other skills and agents as a ground-truth lookup reference, not as a standalone workflow.
+
+resolves equinor/fusion-core-tasks#859

--- a/skills/.system/equinor-design-system/SKILL.md
+++ b/skills/.system/equinor-design-system/SKILL.md
@@ -1,0 +1,232 @@
+---
+name: equinor-design-system
+description: 'Authoritative, machine-readable EDS design rules for color tokens, typography, spacing, elevation, icons, and page layout zones. USE FOR: looking up correct EDS CSS custom properties, typography variant names, spacing tokens, shadow/elevation tokens, icon usage rules, and Fusion Portal page layout conventions. This is a lookup reference consumed by other skills and agents — it has no standalone workflow. DO NOT USE FOR: React component props or usage examples (use fusion-research + mcp_fusion_search_eds), general Copilot coding tasks, or Fusion Framework API questions.'
+license: MIT
+metadata:
+  version: "0.0.0"
+  status: experimental
+  owner: "@equinor/fusion-core"
+  role: subordinate
+  tags:
+    - eds
+    - design-system
+    - design-tokens
+    - color
+    - typography
+    - spacing
+    - elevation
+    - icons
+    - layout
+    - equinor-brand
+    - system-skill
+---
+
+# Equinor Design System — Design Rules
+
+Compact reference for EDS design tokens and Equinor brand constraints. All rules are sourced from [eds.equinor.com](https://eds.equinor.com) and the [Equinor Communication Toolbox](https://communicationtoolbox.equinor.com).
+
+This file is a **subordinate lookup reference**. There are no workflow steps. Consuming agents should look up the relevant section and apply the rule directly.
+
+---
+
+## Color tokens
+
+Use **EDS CSS custom properties** (`--eds-color-*`) for all color values. Never use raw hex, rgb(), or named CSS colors in Fusion app code.
+
+### Primary interactive colors
+
+| Purpose | EDS token |
+|---|---|
+| Primary action (button, link) | `--eds-interactive-primary` |
+| Hover state | `--eds-interactive-primary__hover` |
+| Pressed/active state | `--eds-interactive-primary__active` |
+| Disabled foreground | `--eds-interactive-disabled__text` |
+| Disabled background | `--eds-interactive-disabled__fill` |
+
+### Semantic colors
+
+| Purpose | EDS token |
+|---|---|
+| Success / positive | `--eds-feedback-success` |
+| Warning | `--eds-feedback-warning` |
+| Danger / error | `--eds-feedback-danger` |
+| Informational | `--eds-feedback-info` |
+
+### Text colors
+
+| Purpose | EDS token |
+|---|---|
+| Primary text | `--eds-text-static-icons__primary-white` (on dark) / `--eds-text-static-icons__tertiary` (subtle) |
+| Default body text | Use `color: var(--eds-text-static-icons__default)` |
+| Disabled text | `--eds-text-static-icons__tertiary` |
+
+### UI surface colors
+
+| Purpose | EDS token |
+|---|---|
+| App background | `--eds-ui-background__default` |
+| Elevated surface (card, panel) | `--eds-ui-background__light` |
+| Overlay / scrim | `--eds-ui-background__overlay` |
+| Dividers / borders | `--eds-ui-background__medium` |
+
+> **Brand constraint**: Equinor red (`#FF1243`) is used in the primary logo only — never as a UI action or semantic color. Use EDS interactive tokens for all clickable surfaces.
+
+### Token access in code
+
+Prefer EDS CSS custom properties in styled-components over the `@equinor/eds-tokens` JS object when possible — they respect system dark/light mode automatically.
+
+```typescript
+import styled from 'styled-components';
+
+const Card = styled.div`
+  background: var(--eds-ui-background__light);
+  border: 1px solid var(--eds-ui-background__medium);
+  color: var(--eds-text-static-icons__default);
+`;
+```
+
+---
+
+## Typography
+
+Use `Typography` from `@equinor/eds-core-react` for all text rendering. Never set raw `font-size`, `font-family`, or `line-height` manually — use the EDS `variant` prop.
+
+### Variant hierarchy
+
+| Level | `variant` | Usage |
+|---|---|---|
+| Display | `h1` | Hero headings (rarely used in apps) |
+| Page title | `h2` | Top-level page heading |
+| Section heading | `h3` | Section title, card header |
+| Sub-heading | `h4` | Sub-section, panel title |
+| Overline | `overline` | Category labels, breadcrumb-level text |
+| Body | `body_long` | Multi-line body text |
+| Body short | `body_short` | Single-line body, table cells |
+| Caption | `caption` | Metadata, timestamps, helper text |
+| Label | `label` | Form field labels |
+
+```typescript
+import { Typography } from '@equinor/eds-core-react';
+
+// Correct
+<Typography variant="h3">Section heading</Typography>
+<Typography variant="body_short">Table cell value</Typography>
+<Typography variant="caption">Last updated 2 hours ago</Typography>
+
+// Wrong — never do this
+<p style={{ fontSize: '14px' }}>…</p>
+```
+
+### Brand constraint
+
+Equinor brand typeface is **Equinor** (used in marketing). Fusion apps must use the EDS system typeface defined by `@equinor/eds-core-react` — do not import or override the Equinor brand font in app CSS.
+
+---
+
+## Spacing tokens
+
+Use `--eds-space-*` custom properties for margin and padding. Do not use arbitrary pixel values.
+
+| Token | Value | Use for |
+|---|---|---|
+| `--eds-space-4` | 4 px | XS gap, icon padding |
+| `--eds-space-8` | 8 px | SM gap, tight list spacing |
+| `--eds-space-12` | 12 px | Inner padding (chips, badges) |
+| `--eds-space-16` | 16 px | MD gap, standard content padding |
+| `--eds-space-24` | 24 px | LG gap, section spacing |
+| `--eds-space-32` | 32 px | XL gap, card-to-card separation |
+| `--eds-space-40` | 40 px | XXL gap, major layout breaks |
+| `--eds-space-48` | 48 px | Section-level whitespace |
+
+```typescript
+// Correct
+const Section = styled.section`
+  padding: var(--eds-space-24);
+  margin-bottom: var(--eds-space-16);
+`;
+
+// Wrong
+const Section = styled.section`
+  padding: 24px;   /* arbitrary — use the token */
+  margin-bottom: 16px;
+`;
+```
+
+---
+
+## Elevation and shadow tokens
+
+Use `--eds-elevation-*` for shadow levels. Do not write raw `box-shadow` values.
+
+| Token | Use for |
+|---|---|
+| `--eds-elevation-none` | Flat surface, no elevation |
+| `--eds-elevation-raised` | Cards, inline elevated elements |
+| `--eds-elevation-overlay` | Dropdowns, tooltips, floating elements |
+| `--eds-elevation-raised_overlaying` | Modals, dialogs |
+
+```typescript
+const ElevatedCard = styled.div`
+  box-shadow: var(--eds-elevation-raised);
+`;
+```
+
+---
+
+## Icon usage
+
+Use `@equinor/eds-icons` with the EDS `Icon` component. Do not import SVGs directly or use third-party icon sets.
+
+```typescript
+import { Icon } from '@equinor/eds-core-react';
+import { add, close, settings } from '@equinor/eds-icons';
+
+// Register icons once (e.g. in App.tsx or a global setup file)
+Icon.add({ add, close, settings });
+
+// Use the registered name string
+<Icon name="add" />
+<Icon name="close" size={16} />
+```
+
+Icon sizes follow a fixed scale: `16`, `24` (default), `32`, `40`, `48`. Do not set arbitrary sizes.
+
+---
+
+## Page layout zones
+
+Fusion Portal apps run inside the Fusion Portal shell, which owns the top navigation, left rail, and outer margins. Apps must **not** replicate or conflict with these zones.
+
+### Three-zone app shell
+
+| Zone | Component | Notes |
+|---|---|---|
+| Top bar / header | Provided by Fusion Portal shell | Apps do not render a global header |
+| Main content area | `<main>` or top-level app `<div>` | Full available width and height |
+| Side panel / detail | `@equinor/fusion-react-side-sheet` | Slides in from the right; do not use custom positioned overlays |
+
+### Layout constraints
+
+- **Do not** add outer `margin` or `padding` to the root app component — the portal shell provides the content inset.
+- Use `--eds-space-*` tokens for internal section spacing.
+- **Do not** use fixed `height` on the root container — allow content to stretch to the available viewport height.
+- **Do not** create custom scrollable containers that wrap the full page — the browser scroll is the standard scroll surface.
+- Nested scrollable regions are acceptable for fixed-height grid/table areas, but must be deliberate and clearly bounded.
+
+### Empty and loading states
+
+| State | Pattern |
+|---|---|
+| Loading | EDS `CircularProgress` or Fusion `ProgressIndicator` centered in content area |
+| Empty (no data) | EDS `Typography` + optional EDS `Button` for a primary action; centered or top-aligned |
+| Error | EDS `Typography variant="body_short"` with red semantic color + retry action |
+
+---
+
+## Sources
+
+- EDS design resources: https://eds.equinor.com/docs/resources/
+- EDS component library: https://eds.equinor.com/components/
+- Equinor brand color: https://communicationtoolbox.equinor.com/point/en/equinor/component/default/100056
+- Equinor brand typography: https://communicationtoolbox.equinor.com/point/en/equinor/component/default/100059
+- Equinor brand layout: https://communicationtoolbox.equinor.com/point/en/equinor/component/default/100061

--- a/skills/.system/equinor-design-system/SKILL.md
+++ b/skills/.system/equinor-design-system/SKILL.md
@@ -190,13 +190,13 @@ const Section = styled.section`
 `;
 ```
 
-### Border radius tokens
+### Border radius
 
-| Token | Use for |
+| Token / value | Use for |
 |---|---|
-| `--eds-spacing-border-radius-none` | Square corners (0 px) |
-| `--eds-spacing-border-radius-rounded` | Standard card / button radius |
-| `--eds-spacing-border-radius-pill` | Full pill (tags, chips) |
+| `--eds-shape-corners-border-radius` | Standard rounded corners (cards, buttons) |
+| `border-radius: 0` | Sharp / square corners |
+| `border-radius: 9999px` | Full pill (tags, chips) |
 
 ---
 
@@ -219,18 +219,16 @@ If you need raw `box-shadow` values from JS (rare): import from `@equinor/eds-to
 
 ## Icon usage
 
-Use `@equinor/eds-icons` with the EDS `Icon` component. Do not import SVGs directly or use third-party icon sets.
+Use `@equinor/eds-icons` with the EDS `Icon` component. Do not import SVGs directly or use third-party icon sets. Always pass icon data via the `data` prop — do not use the `name` string prop. Icon names from `@equinor/eds-icons` are in `snake_case`.
 
 ```typescript
 import { Icon } from '@equinor/eds-core-react';
 import { add, close, settings } from '@equinor/eds-icons';
 
-// Register icons once (e.g. in App.tsx or a global setup file)
-Icon.add({ add, close, settings });
-
-// Use the registered name string
-<Icon name="add" />
-<Icon name="close" size={16} />
+// Pass icon data object via the `data` prop; provide `title` for accessibility
+<Icon data={add} title="Add" />
+<Icon data={close} title="Close" size={16} />
+<Icon data={settings} title="Settings" />
 ```
 
 Icon sizes follow a fixed scale: `16`, `24` (default), `32`, `40`, `48`. Do not set arbitrary sizes.
@@ -252,7 +250,7 @@ Fusion Portal apps run inside the Fusion Portal shell, which owns the top naviga
 ### Layout constraints
 
 - **Do not** add outer `margin` or `padding` to the root app component — the portal shell provides the content inset.
-- Use `--eds-space-*` tokens for internal section spacing.
+- Use `--eds-spacing-horizontal-<size>` / `--eds-spacing-vertical-<size>` tokens for internal section spacing.
 - **Do not** use fixed `height` on the root container — allow content to stretch to the available viewport height.
 - **Do not** create custom scrollable containers that wrap the full page — the browser scroll is the standard scroll surface.
 - Nested scrollable regions are acceptable for fixed-height grid/table areas, but must be deliberate and clearly bounded.
@@ -261,9 +259,9 @@ Fusion Portal apps run inside the Fusion Portal shell, which owns the top naviga
 
 | State | Pattern |
 |---|---|
-| Loading | EDS `CircularProgress` or Fusion `ProgressIndicator` centered in content area |
+| Loading | EDS `CircularProgress` or `@equinor/fusion-react-progress-indicator` `ProgressIndicator` centered in content area |
 | Empty (no data) | EDS `Typography` + optional EDS `Button` for a primary action; centered or top-aligned |
-| Error | EDS `Typography variant="body_short"` with red semantic color + retry action |
+| Error | EDS `Typography variant="body_short"` colored with `--eds-color-text-danger-strong` + retry action |
 
 ---
 

--- a/skills/.system/equinor-design-system/SKILL.md
+++ b/skills/.system/equinor-design-system/SKILL.md
@@ -31,45 +31,71 @@ This file is a **subordinate lookup reference**. There are no workflow steps. Co
 
 ## Color tokens
 
-Use **EDS CSS custom properties** (`--eds-color-*`) for all color values. Never use raw hex, rgb(), or named CSS colors in Fusion app code.
+Use **EDS CSS custom properties** (`--eds-color-*`) for all color values. Never use raw hex, rgb(), or named CSS colors in Fusion app code. All tokens below are from `@equinor/eds-tokens` v2.x (the version Fusion apps depend on).
 
-### Primary interactive colors
+> Token naming pattern: `--eds-color-<layer>-<semantic>-<variant>`
+> - `bg` = background fill
+> - `text` = foreground text / icon
+> - `border` = stroke / divider
 
-| Purpose | EDS token |
-|---|---|
-| Primary action (button, link) | `--eds-interactive-primary` |
-| Hover state | `--eds-interactive-primary__hover` |
-| Pressed/active state | `--eds-interactive-primary__active` |
-| Disabled foreground | `--eds-interactive-disabled__text` |
-| Disabled background | `--eds-interactive-disabled__fill` |
-
-### Semantic colors
+### Background tokens
 
 | Purpose | EDS token |
 |---|---|
-| Success / positive | `--eds-feedback-success` |
-| Warning | `--eds-feedback-warning` |
-| Danger / error | `--eds-feedback-danger` |
-| Informational | `--eds-feedback-info` |
+| Page / app canvas | `--eds-color-bg-canvas` |
+| Surface (card, panel) | `--eds-color-bg-surface` |
+| Input field background | `--eds-color-bg-input` |
+| Floating surface (dropdown, tooltip) | `--eds-color-bg-floating` |
+| Backdrop / modal scrim | `--eds-color-bg-backdrop` |
+| Primary action fill (default) | `--eds-color-bg-fill-emphasis-default` |
+| Primary action fill (hover) | `--eds-color-bg-fill-emphasis-hover` |
+| Primary action fill (active) | `--eds-color-bg-fill-emphasis-active` |
+| Muted fill (default) | `--eds-color-bg-fill-muted-default` |
+| Muted fill (hover) | `--eds-color-bg-fill-muted-hover` |
+| Disabled surface | `--eds-color-bg-disabled` |
+| Success surface (subtle bg) | `--eds-color-bg-success-surface` |
+| Success fill (emphasis) | `--eds-color-bg-success-fill-emphasis-default` |
+| Warning surface | `--eds-color-bg-warning-surface` |
+| Warning fill (emphasis) | `--eds-color-bg-warning-fill-emphasis-default` |
+| Danger / error surface | `--eds-color-bg-danger-surface` |
+| Danger fill (emphasis) | `--eds-color-bg-danger-fill-emphasis-default` |
+| Info surface | `--eds-color-bg-info-surface` |
+| Info fill (emphasis) | `--eds-color-bg-info-fill-emphasis-default` |
+| Accent surface | `--eds-color-bg-accent-surface` |
+| Accent fill (emphasis) | `--eds-color-bg-accent-fill-emphasis-default` |
 
-### Text colors
+### Text tokens
 
 | Purpose | EDS token |
 |---|---|
-| Primary text | `--eds-text-static-icons__primary-white` (on dark) / `--eds-text-static-icons__tertiary` (subtle) |
-| Default body text | Use `color: var(--eds-text-static-icons__default)` |
-| Disabled text | `--eds-text-static-icons__tertiary` |
+| Primary body text | `--eds-color-text-strong` |
+| Text on emphasis/filled backgrounds | `--eds-color-text-strong-on-emphasis` |
+| Subtle / secondary text | `--eds-color-text-subtle` |
+| Disabled text | `--eds-color-text-disabled` |
+| Link | `--eds-color-text-link` |
+| Success text | `--eds-color-text-success-strong` |
+| Success text (subtle) | `--eds-color-text-success-subtle` |
+| Warning text | `--eds-color-text-warning-strong` |
+| Danger / error text | `--eds-color-text-danger-strong` |
+| Info text | `--eds-color-text-info-strong` |
+| Accent text | `--eds-color-text-accent-strong` |
 
-### UI surface colors
+### Border tokens
 
 | Purpose | EDS token |
 |---|---|
-| App background | `--eds-ui-background__default` |
-| Elevated surface (card, panel) | `--eds-ui-background__light` |
-| Overlay / scrim | `--eds-ui-background__overlay` |
-| Dividers / borders | `--eds-ui-background__medium` |
+| Default divider / border | `--eds-color-border-medium` |
+| Subtle border | `--eds-color-border-subtle` |
+| Strong border | `--eds-color-border-strong` |
+| Focus ring | `--eds-color-border-focus` |
+| Disabled border | `--eds-color-border-disabled` |
+| Success border | `--eds-color-border-success-medium` |
+| Warning border | `--eds-color-border-warning-medium` |
+| Danger border | `--eds-color-border-danger-medium` |
+| Info border | `--eds-color-border-info-medium` |
+| Accent border | `--eds-color-border-accent-medium` |
 
-> **Brand constraint**: Equinor red (`#FF1243`) is used in the primary logo only — never as a UI action or semantic color. Use EDS interactive tokens for all clickable surfaces.
+> **Brand constraint**: Equinor red (`#FF1243`) is used in the primary logo only — never as a UI action or semantic color. Use EDS color tokens for all clickable and semantic surfaces.
 
 ### Token access in code
 
@@ -79,9 +105,23 @@ Prefer EDS CSS custom properties in styled-components over the `@equinor/eds-tok
 import styled from 'styled-components';
 
 const Card = styled.div`
-  background: var(--eds-ui-background__light);
-  border: 1px solid var(--eds-ui-background__medium);
-  color: var(--eds-text-static-icons__default);
+  background: var(--eds-color-bg-surface);
+  border: 1px solid var(--eds-color-border-medium);
+  color: var(--eds-color-text-strong);
+`;
+
+const PrimaryButton = styled.button`
+  background: var(--eds-color-bg-fill-emphasis-default);
+  color: var(--eds-color-text-strong-on-emphasis);
+
+  &:hover {
+    background: var(--eds-color-bg-fill-emphasis-hover);
+  }
+
+  &:disabled {
+    background: var(--eds-color-bg-disabled);
+    color: var(--eds-color-text-disabled);
+  }
 `;
 ```
 
@@ -125,51 +165,55 @@ Equinor brand typeface is **Equinor** (used in marketing). Fusion apps must use 
 
 ## Spacing tokens
 
-Use `--eds-space-*` custom properties for margin and padding. Do not use arbitrary pixel values.
+Use `--eds-spacing-horizontal-<size>` and `--eds-spacing-vertical-<size>` from `@equinor/eds-tokens` v2 for margin, padding, and gap. Do not use arbitrary pixel values.
 
-| Token | Value | Use for |
-|---|---|---|
-| `--eds-space-4` | 4 px | XS gap, icon padding |
-| `--eds-space-8` | 8 px | SM gap, tight list spacing |
-| `--eds-space-12` | 12 px | Inner padding (chips, badges) |
-| `--eds-space-16` | 16 px | MD gap, standard content padding |
-| `--eds-space-24` | 24 px | LG gap, section spacing |
-| `--eds-space-32` | 32 px | XL gap, card-to-card separation |
-| `--eds-space-40` | 40 px | XXL gap, major layout breaks |
-| `--eds-space-48` | 48 px | Section-level whitespace |
+The horizontal and vertical scales share the same size steps but may differ by a few pixels at each step; use the axis-appropriate token (horizontal for left/right, vertical for top/bottom).
+
+| Size | Horizontal value | Vertical value | Use for |
+|---|---|---|---|
+| `4xs` | 2 px | 2 px | Micro gap, tight icon padding |
+| `3xs` | 4 px | 4 px | XS gap |
+| `2xs` | 6 px | 6 px | Small inset padding |
+| `xs` | 8 px | 8 px | SM gap, compact list spacing |
+| `sm` | 12 px | 12 px | Inner padding (chips, badges) |
+| `md` | 16 px | 16 px | Standard content padding |
+| `lg` | 20 px | 20 px | LG gap, section spacing |
+| `xl` | 24 px | 24 px | XL gap, card separation |
+| `2xl` | 28 px | 28 px | Major section break |
+| `3xl` | 32 px | 32 px | Section-level whitespace |
 
 ```typescript
-// Correct
 const Section = styled.section`
-  padding: var(--eds-space-24);
-  margin-bottom: var(--eds-space-16);
-`;
-
-// Wrong
-const Section = styled.section`
-  padding: 24px;   /* arbitrary — use the token */
-  margin-bottom: 16px;
+  padding-inline: var(--eds-spacing-horizontal-md);
+  padding-block: var(--eds-spacing-vertical-lg);
+  gap: var(--eds-spacing-vertical-sm);
 `;
 ```
 
----
-
-## Elevation and shadow tokens
-
-Use `--eds-elevation-*` for shadow levels. Do not write raw `box-shadow` values.
+### Border radius tokens
 
 | Token | Use for |
 |---|---|
-| `--eds-elevation-none` | Flat surface, no elevation |
-| `--eds-elevation-raised` | Cards, inline elevated elements |
-| `--eds-elevation-overlay` | Dropdowns, tooltips, floating elements |
-| `--eds-elevation-raised_overlaying` | Modals, dialogs |
+| `--eds-spacing-border-radius-none` | Square corners (0 px) |
+| `--eds-spacing-border-radius-rounded` | Standard card / button radius |
+| `--eds-spacing-border-radius-pill` | Full pill (tags, chips) |
+
+---
+
+## Elevation and shadow
+
+EDS v2 (`@equinor/eds-tokens` ^2) does not expose elevation as CSS custom properties. For elevated surfaces use the EDS `Paper` component which applies the correct shadow for its variant, or use EDS `Elevation` tokens via the JS object import from `@equinor/eds-tokens` when you need raw values in styled-components.
 
 ```typescript
-const ElevatedCard = styled.div`
-  box-shadow: var(--eds-elevation-raised);
-`;
+import { Paper } from '@equinor/eds-core-react';
+
+// Prefer Paper for cards/panels — elevation is handled automatically
+<Paper elevation="raised">
+  <CardContent />
+</Paper>
 ```
+
+If you need raw `box-shadow` values from JS (rare): import from `@equinor/eds-tokens`, not hardcoded values.
 
 ---
 


### PR DESCRIPTION
## Why

The skills catalog had no subordinate reference for the Equinor Design System (EDS). Skills that need to give ground-truth guidance on color tokens, typography variants, spacing/elevation tokens, and icon usage had no authoritative source to reference or delegate to.

## Current behavior

No EDS system skill. Skills referencing EDS design tokens or component patterns must inline that knowledge or leave it unspecified.

## New behavior

New subordinate skill `skills/.system/equinor-design-system/SKILL.md` with:
- Color tokens (interactive, semantic, text, surface)
- Typography variant hierarchy
- Spacing (`--eds-space-*`) and elevation (`--eds-elevation-*`) tokens
- Icon usage via `@equinor/eds-icons`
- Fusion Portal three-zone page layout conventions
- Empty/loading/error state patterns
- Source links to EDS and Fusion documentation

## References

- Issue(s): Resolves equinor/fusion-core-tasks#859
- Related PR(s): equinor/fusion-skills#(#860 — design agent that uses this skill)
- Docs / specs: [EDS documentation](https://eds.equinor.com/)

## Reviewer focus

- Start here: `skills/.system/equinor-design-system/SKILL.md`
- Verify these behavior changes: subordinate skill is correctly identified (`role: subordinate`, `status: experimental`), token names are accurate against EDS docs
- Risky or security-sensitive parts: none

## Self review checklist

- [x] I scoped this PR to one clear purpose.
- [x] I followed [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I did not include secrets, credentials, or sensitive data.
- [x] I reviewed my own diff for clarity and unintended changes.
