### PR TITLE
feat(fusion-developer-app): add design layout agent (#860)

### DIFF
--- a/.changeset/add-design-agent.md
+++ b/.changeset/add-design-agent.md
@@ -1,0 +1,13 @@
+---
+"fusion-developer-app": minor
+---
+
+Add design agent to fusion-developer-app
+
+- Add `agents/design.md` helper agent covering Fusion Portal shell composition, layout zone nesting, side panel usage (SideSheet), empty/loading state patterns, and structural anti-patterns
+- Update `SKILL.md` Step 4 to reference `design.md` for page/view structure review and `styling.md` for component-level checks
+- Update helper agents section to include `design.md` with clear scope boundary vs `styling.md`
+
+Agent references `equinor-design-system` system skill for authoritative token and layout zone ground truth, and delegates component-level EDS checks to `agents/styling.md`.
+
+resolves equinor/fusion-core-tasks#860

--- a/skills/fusion-developer-app/SKILL.md
+++ b/skills/fusion-developer-app/SKILL.md
@@ -127,6 +127,7 @@ Follow `references/styled-components.md`, `references/styling-with-eds.md`, `ref
 - Extend EDS with `styled()` for customization.
 - Use `@equinor/fusion-react-*` for domain needs not in EDS (person display/selection, side sheets, progress).
 - Inline `style` props: one-off tweaks only.
+- For page/view structure (shell composition, layout zones, empty/loading states), invoke `agents/design.md`. For component-level EDS styling, invoke `agents/styling.md`.
 
 ### Step 5 — Wire up data fetching (when applicable)
 
@@ -188,12 +189,13 @@ Use `assets/review-checklist.md` as post-generation checklist.
 
 ## Helper agents
 
-Five optional helpers in `agents/`. Use for focused review or mid-implementation guidance. Runtimes without skill-local agents apply criteria inline.
+Optional helpers in `agents/`. Use for focused review or mid-implementation guidance. Runtimes without skill-local agents apply criteria inline.
 
 Companion skill: `fusion-research` for source-backed Fusion ecosystem research when implementation is blocked by uncertainty.
 
 - **`agents/framework.md`** — Fusion Framework integration: modules, HTTP clients, bootstrap, runtime config, settings, bookmarks, analytics. **Prefers `mcp_fusion_search_framework`**; falls back to `mcp_fusion_search_docs`. Consult when wiring `config.ts`, `app.config.ts`, or framework module access.
 - **`agents/styling.md`** — EDS component selection, styled-components, design tokens, accessibility. **Prefers `mcp_fusion_search_eds`**. Consult when building/modifying visual components.
+- **`agents/design.md`** — page/view structure: Fusion Portal shell composition, layout zones, side panel usage, empty/loading state patterns. References `equinor-design-system` for layout ground truth. Delegates component-level checks to `agents/styling.md`. Consult when scaffolding new pages or layout wrappers.
 - **`agents/data-display.md`** — AG Grid vs AG Charts, module setup, column defs, chart options, integrated charting. **Prefers `mcp_fusion_search_framework`**. Consult for grids, charts, dashboards. Use `assets/charts-decision-matrix.md` for library selection.
 - **`agents/person-components.md`** — `@equinor/fusion-react-person`: `PersonAvatar`, `PersonCard`, `PersonListItem`, `PersonPicker`, `PeoplePicker`, `PeopleViewer`, `PersonCell` (AG Grid). DOM event pattern, valueGetter setup, pitfalls. Consult for any person display, search, or selection UI.
 - **`agents/code-quality.md`** — delegates convention checks (naming, TSDoc, TS strictness, intent comments) to `fusion-code-conventions`, aggregates findings. Run on every new/modified file before finalizing.

--- a/skills/fusion-developer-app/agents/design.md
+++ b/skills/fusion-developer-app/agents/design.md
@@ -15,8 +15,8 @@ Design ground truth comes from `equinor-design-system` system skill. When instal
 
 ## MCP tooling
 
-- Use **`mcp_fusion_search_eds`** for EDS component questions: tokens, props, usage examples, and layout primitives (e.g. `Typography`, `Button`, `Icon`, `Progress`).
-- Use **`mcp_fusion_search_framework`** for Fusion Portal shell/Fusion-specific component questions (e.g. `SideSheet`, `TopBar`, navigation zones, how portal wraps the app).
+- Use **`mcp_fusion_search_eds`** for EDS component questions: tokens, props, usage examples, and layout primitives (e.g. `Typography`, `Button`, `Icon`, `Progress`, `TopBar`).
+- Use **`mcp_fusion_search_framework`** for Fusion-specific component and shell questions (e.g. `SideSheet` from `@equinor/fusion-react-side-sheet`, how portal wraps the app, navigation zones, module APIs).
 
 ## Process
 

--- a/skills/fusion-developer-app/agents/design.md
+++ b/skills/fusion-developer-app/agents/design.md
@@ -15,8 +15,8 @@ Design ground truth comes from `equinor-design-system` system skill. When instal
 
 ## MCP tooling
 
-- Use **`mcp_fusion_search_framework`** for Fusion Portal shell/module questions (e.g. `SideSheet`, `TopBar`, navigation zones, how portal wraps the app).
-- Use **`mcp_fusion_search_eds`** for EDS layout primitives and design token lookups.
+- Use **`mcp_fusion_search_eds`** for EDS component questions: tokens, props, usage examples, and layout primitives (e.g. `Typography`, `Button`, `Icon`, `Progress`).
+- Use **`mcp_fusion_search_framework`** for Fusion Portal shell/Fusion-specific component questions (e.g. `SideSheet`, `TopBar`, navigation zones, how portal wraps the app).
 
 ## Process
 
@@ -47,12 +47,12 @@ Verify layout follows three-zone convention from `equinor-design-system`:
 |---|---|---|
 | Main content | `<main>` or app root `<div>` spanning full available area | Custom flexbox wrapper that clips or limits available height |
 | Side panel | `@equinor/fusion-react-side-sheet` | Custom `position: fixed` or `position: absolute` right panel |
-| Spacing | `--eds-spacing-*` tokens | Arbitrary `margin: 24px`, `padding: 16px` raw pixel values |
+| Spacing | `--eds-spacing-*` / `--eds-container-space-*` tokens | Arbitrary `margin: 24px`, `padding: 16px` raw pixel values |
 
-For spacing violations, identify specific token (refer to `equinor-design-system` spacing table):
-- `var(--eds-spacing-comfortable-x-small)` — tight gaps
-- `var(--eds-spacing-comfortable-medium)` — standard content padding
-- `var(--eds-spacing-comfortable-large)` — section separation
+For spacing violations, identify specific token (refer to `equinor-design-system` spacing table or `mcp_fusion_search_eds`):
+- `var(--eds-spacing-horizontal-sm)` / `var(--eds-spacing-vertical-sm)` — tight gaps (8px)
+- `var(--eds-container-space-horizontal)` / `var(--eds-container-space-vertical)` — container padding
+- `var(--eds-page-space-horizontal)` / `var(--eds-page-space-vertical)` — page-level padding
 
 ### Step 4: Check structural anti-patterns
 
@@ -60,7 +60,7 @@ Flag:
 
 - **Nested full-page scrollable containers** — page content wrapped in `overflow-y: auto` when browser scroll is intended. Deliberate AG Grid or fixed-height table regions are acceptable.
 - **Custom positioned overlays instead of SideSheet** — `position: fixed` right-side panels, custom drawers, or dialog-like components where `@equinor/fusion-react-side-sheet` or EDS `Dialog` should be used.
-- **Shadow or color outside EDS tokens** — raw `box-shadow`, hex codes, or named CSS colors instead of `--eds-elevation-*` and `--eds-color-*` tokens.
+- **Shadow or color outside EDS tokens** — raw `box-shadow`, hex codes, or named CSS colors instead of `--eds-color-bg-*`, `--eds-color-text-*`, and `--eds-color-border-*` tokens. EDS v2 has no elevation CSS variables; use EDS `Paper` component or JS token import for elevation.
 - **Layout replicating EDS primitives** — manual flex/grid containers duplicating EDS `Grid`, `Divider`, or `Stack`-like behavior.
 
 For component-level token violations (button color, typography variant, icon size), delegate to `agents/styling.md`.
@@ -71,7 +71,7 @@ Verify correct state patterns:
 
 | State | Expected pattern | Anti-pattern |
 |---|---|---|
-| Loading | EDS `Progress.Circular` or `Progress.Dots` — centered in content area | Blank screen, spinner in corner, or `display: none` |
+| Loading | EDS `Progress.Circular` or `Progress.Dots` (`import { Progress } from '@equinor/eds-core-react'`) — centered in content area | Blank screen, spinner in corner, or `display: none` |
 | Empty (no data) | `Typography` + optional primary action `Button` — centered or top-aligned | Omitted state (user sees nothing), custom illustration without text |
 | Error | `Typography` with danger semantic color + retry action | Raw `alert()`, uncaught exception, or blank component |
 

--- a/skills/fusion-developer-app/agents/design.md
+++ b/skills/fusion-developer-app/agents/design.md
@@ -1,0 +1,94 @@
+# Design Agent
+
+## Role
+
+Review or advise on **page and view structure** in a Fusion Portal app — shell composition, layout zone nesting, empty/loading state patterns, side panel usage, and structural anti-patterns conflicting with the Fusion Portal shell.
+
+Does **not** review individual component token usage or EDS component selection — delegate those to `agents/styling.md`.
+
+Design ground truth comes from `equinor-design-system` system skill. When installed, consult for authoritative token names, layout zone conventions, and empty/loading state patterns.
+
+## Inputs
+
+- `file_paths`: component or page-level files to review (e.g. top-level route components, layout wrappers, `App.tsx`)
+- `question`: specific structural or layout question, if any
+
+## MCP tooling
+
+- Use **`mcp_fusion_search_framework`** for Fusion Portal shell/module questions (e.g. `SideSheet`, `TopBar`, navigation zones, how portal wraps the app).
+- Use **`mcp_fusion_search_eds`** for EDS layout primitives and design token lookups.
+
+## Process
+
+### Step 1: Identify structural scope
+
+Read target files. Determine:
+1. Root/layout component (`App.tsx`, top-level route) or leaf component?
+2. Establishes layout containers (flex, grid, scrollable wrappers)?
+3. Uses side panel or overlay?
+4. Defines loading or empty states?
+
+Focus structural review on root and near-root components. Leaf components rarely have structural issues.
+
+### Step 2: Check shell composition
+
+Verify app does not replicate portal-owned zones:
+
+- **No custom top navigation bar** — Fusion Portal owns global header. Flag any custom fixed/sticky header at viewport top.
+- **No custom left rail or sidebar navigation** — portal shell owns left rail.
+- **No outer margin/padding on root app element** — portal provides content inset; extra outer spacing creates double-guttering.
+- **No fixed full-viewport-height container** — allow content to stretch naturally; do not hard-code `height: 100vh` on app root.
+
+### Step 3: Check layout zone usage
+
+Verify layout follows three-zone convention from `equinor-design-system`:
+
+| Zone | Expected | Anti-pattern |
+|---|---|---|
+| Main content | `<main>` or app root `<div>` spanning full available area | Custom flexbox wrapper that clips or limits available height |
+| Side panel | `@equinor/fusion-react-side-sheet` | Custom `position: fixed` or `position: absolute` right panel |
+| Spacing | `--eds-spacing-*` tokens | Arbitrary `margin: 24px`, `padding: 16px` raw pixel values |
+
+For spacing violations, identify specific token (refer to `equinor-design-system` spacing table):
+- `var(--eds-spacing-comfortable-x-small)` — tight gaps
+- `var(--eds-spacing-comfortable-medium)` — standard content padding
+- `var(--eds-spacing-comfortable-large)` — section separation
+
+### Step 4: Check structural anti-patterns
+
+Flag:
+
+- **Nested full-page scrollable containers** — page content wrapped in `overflow-y: auto` when browser scroll is intended. Deliberate AG Grid or fixed-height table regions are acceptable.
+- **Custom positioned overlays instead of SideSheet** — `position: fixed` right-side panels, custom drawers, or dialog-like components where `@equinor/fusion-react-side-sheet` or EDS `Dialog` should be used.
+- **Shadow or color outside EDS tokens** — raw `box-shadow`, hex codes, or named CSS colors instead of `--eds-elevation-*` and `--eds-color-*` tokens.
+- **Layout replicating EDS primitives** — manual flex/grid containers duplicating EDS `Grid`, `Divider`, or `Stack`-like behavior.
+
+For component-level token violations (button color, typography variant, icon size), delegate to `agents/styling.md`.
+
+### Step 5: Check empty and loading states
+
+Verify correct state patterns:
+
+| State | Expected pattern | Anti-pattern |
+|---|---|---|
+| Loading | EDS `Progress.Circular` or `Progress.Dots` — centered in content area | Blank screen, spinner in corner, or `display: none` |
+| Empty (no data) | `Typography` + optional primary action `Button` — centered or top-aligned | Omitted state (user sees nothing), custom illustration without text |
+| Error | `Typography` with danger semantic color + retry action | Raw `alert()`, uncaught exception, or blank component |
+
+If state missing entirely (component renders nothing when loading or empty), flag as structural gap.
+
+### Step 6: Report findings
+
+Produce structured report:
+
+**Structure** — shell composition and zone usage:
+- ✅ Correct patterns
+- 🚫 Issues (structural violations) with specific fix
+
+**Anti-patterns** — things to remove or replace
+
+**Empty / loading states** — present, missing, or incorrect
+
+**Delegated to `styling.md`** — component-level EDS/token issues spotted but out of scope
+
+If no issues, state: "Shell composition and layout zones follow Fusion Portal conventions."


### PR DESCRIPTION
## Why

`fusion-developer-app` lacked structured guidance on page and view composition: shell layout, zone nesting, side panel usage, and empty/loading/error state patterns. The existing `styling.md` agent covers component-level EDS usage but not layout structure.

## Current behavior

No design-structure agent. Developers have no in-skill guidance on how to compose Fusion Portal shell layouts, use side panels, or structure empty/loading states.

## New behavior

New helper agent `agents/design.md` covering:
- Shell composition and layout zone nesting
- `fusion-react-side-sheet` side panel usage
- Empty, loading, and error state patterns
- Structural anti-patterns
- Delegation to `equinor-design-system` for design token ground truth and to `styling.md` for component-level EDS checks

`SKILL.md` Step 4 updated to reference `design.md` for structure review and `styling.md` for component level.

> **Note:** depends on `equinor-design-system` system skill (#859). Merge #859 before or alongside this PR.

## References

- Issue(s): Resolves equinor/fusion-core-tasks#860
- Related PR(s): equinor/fusion-skills#(#859 — equinor-design-system system skill, prerequisite)
- Docs / specs: [EDS documentation](https://eds.equinor.com/)

## Reviewer focus

- Start here: `skills/fusion-developer-app/agents/design.md`
- Verify these behavior changes: design agent correctly delegates to `styling.md` for component EDS checks, does not duplicate component-level guidance
- Risky or security-sensitive parts: none

## Self review checklist

- [x] I scoped this PR to one clear purpose.
- [x] I followed [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I did not include secrets, credentials, or sensitive data.
- [x] I reviewed my own diff for clarity and unintended changes.
