### PR TITLE
feat(fusion-developer-app): add custom module authoring reference (#753)

### DIFF
--- a/.changeset/add-custom-module-reference.md
+++ b/.changeset/add-custom-module-reference.md
@@ -1,0 +1,11 @@
+---
+"fusion-developer-app": minor
+---
+
+Add custom Fusion Framework module authoring reference
+
+- Add `references/using-custom-modules.md` covering the IModule contract, wiring into `config.ts`, accessing via `useAppModule`, module lifecycle, file structure, and common pitfalls (naming conflicts, outside-React access, un-awaited config)
+- Update `SKILL.md` Step 6 module table with a `using-custom-modules.md` entry
+- Add custom-module-related activation triggers
+
+resolves equinor/fusion-core-tasks#753

--- a/skills/fusion-developer-app/SKILL.md
+++ b/skills/fusion-developer-app/SKILL.md
@@ -48,8 +48,9 @@ Typical triggers:
 - "Add a feature flag to this app"
 - "How do I use the useFeature hook in a Fusion app?"
 - "Implement a feature for ..."
-- "Add a chart to this page"
-- "How do I use AG Charts in my Fusion app?"
+- "Add a chart to this page"- "How do I write a custom Fusion Framework module?"
+- "Should this be a Fusion module or a React context?"
+- "Wire a custom module into config.ts"- "How do I use AG Charts in my Fusion app?"
 - "Create a dashboard with charts"
 
 Implicit triggers:
@@ -169,6 +170,7 @@ Identify which module the user needs, then read only the matching reference:
 | Runtime config / environment | `references/using-assets-and-environment.md` |
 | Feature flags | `references/using-feature-flags.md` |
 | General framework modules | `references/using-framework-modules.md` |
+| Custom module authoring | `references/using-custom-modules.md` |
 
 - Add module setup in `config.ts` using the `AppModuleInitiator` callback.
 - Access modules in components via hooks: `useAppModule`, `useHttpClient`, `useCurrentContext`.

--- a/skills/fusion-developer-app/SKILL.md
+++ b/skills/fusion-developer-app/SKILL.md
@@ -48,9 +48,12 @@ Typical triggers:
 - "Add a feature flag to this app"
 - "How do I use the useFeature hook in a Fusion app?"
 - "Implement a feature for ..."
-- "Add a chart to this page"- "How do I write a custom Fusion Framework module?"
+- "Add a chart to this page"
+- "How do I use AG Charts in my Fusion app?"
+- "Create a dashboard with charts"
+- "How do I write a custom Fusion Framework module?"
 - "Should this be a Fusion module or a React context?"
-- "Wire a custom module into config.ts"- "How do I use AG Charts in my Fusion app?"
+- "Wire a custom module into config.ts"
 - "Create a dashboard with charts"
 
 Implicit triggers:

--- a/skills/fusion-developer-app/references/using-custom-modules.md
+++ b/skills/fusion-developer-app/references/using-custom-modules.md
@@ -1,0 +1,121 @@
+# Authoring Custom Fusion Framework Modules
+
+How to package reusable cross-cutting behavior as a Fusion Framework module in a React app — the module lifecycle, configuration pattern, and when a custom module is the right tool.
+
+**Fusion docs**: [Fusion Framework modules](https://docs.equinor.com/fusion-framework/)
+**Cookbook**: See the custom module cookbook example in the Fusion Framework source (`packages/modules/`)
+
+## When to use a custom module
+
+A custom Fusion Framework module is appropriate when:
+- You need reusable, cross-cutting behavior that multiple components or routes need access to
+- The behavior depends on the Fusion bootstrap lifecycle (needs access to the framework instance at startup)
+- You want to decouple infrastructure concerns (caching, subscriptions, service clients) from component code
+
+A custom module is **not** appropriate for:
+- Single-component-only state — use React state or context instead
+- Data fetching that only one page needs — use a React Query hook in that page
+- Generic utility functions — use a plain TypeScript module
+
+## Module contract
+
+Every custom module must implement the `IModule` interface from `@equinor/fusion-framework-module`:
+
+```typescript
+import type { IModule } from '@equinor/fusion-framework-module';
+
+export interface IMyModuleConfig {
+  // Configuration shape for your module
+  apiBaseUrl: string;
+}
+
+export interface IMyModule {
+  // Public API your module exposes to the app
+  getClient(): MyApiClient;
+}
+
+export const module: IModule<IMyModule, IMyModuleConfig> = {
+  name: 'myModule', // Unique module key — must not conflict with built-in modules
+  initialize: async ({ config, instance }): Promise<IMyModule> => {
+    const cfg = await config;
+    const client = new MyApiClient(cfg.apiBaseUrl);
+    return { getClient: () => client };
+  },
+};
+```
+
+## Wiring a custom module into an app
+
+Register the module in `src/config.ts` using the `AppModuleInitiator` callback:
+
+```typescript
+import type { AppModuleInitiator } from '@equinor/fusion-framework-react-app';
+import { module as myModule } from './modules/myModule';
+
+export const configure: AppModuleInitiator = (configurator) => {
+  // Built-in modules
+  configurator.useFrameworkServiceClient('myService');
+
+  // Custom module
+  configurator.addModule(myModule, (moduleConfigurator) => {
+    moduleConfigurator.setConfig({
+      apiBaseUrl: 'https://api.example.com',
+    });
+  });
+};
+```
+
+## Accessing a custom module in components
+
+Use `useAppModule` from `@equinor/fusion-framework-react-app` with the module name key:
+
+```typescript
+import { useAppModule } from '@equinor/fusion-framework-react-app';
+import type { IMyModule } from '../modules/myModule';
+
+const MyFeatureComponent = () => {
+  // Type the module by its interface
+  const myModule = useAppModule<IMyModule>('myModule');
+  const client = myModule.getClient();
+
+  // Use the client in a React Query hook or useEffect
+};
+```
+
+> Only call `useAppModule` inside React components or custom hooks — it is a React hook and must follow React rules.
+
+## Module lifecycle
+
+Fusion Framework initializes modules before the React app mounts. The lifecycle is:
+
+1. `initialize` — called once at bootstrap with the merged config and a reference to the parent framework instance
+2. Module is stored in the framework instance under its `name` key
+3. Components access the module via `useAppModule(name)` after mount
+
+There is no `destroy` lifecycle on most modules. If your module opens subscriptions or connections, clean them up in your components (e.g. via `useEffect` cleanup).
+
+## File structure
+
+A conventional custom module lives alongside the app source:
+
+```
+src/
+  modules/
+    myModule/
+      index.ts       — module definition + exports
+      MyApiClient.ts — implementation
+  config.ts          — registermodule here
+```
+
+## Common pitfalls
+
+- **Naming conflicts**: the module `name` must not collide with built-in Fusion module names (`http`, `auth`, `context`, `navigation`, `featureFlag`, `settings`, `bookmarks`, `analytics`). Use a unique name specific to your app or domain.
+- **Accessing modules outside React**: `useAppModule` is a hook and cannot be called outside components. For route loaders or non-React contexts, access the framework instance directly via `framework.modules.<name>`.
+- **Config not awaited**: the `initialize` callback receives a `Promise<config>` — always `await config` before reading config values.
+- **Over-engineering**: if only one component needs the behavior, a hook or React context is simpler. Use a module when multiple disconnected parts of the app share the same infrastructure.
+
+## When to use `fusion-research` first
+
+If uncertain about specific module API signatures, available module names, or how built-in module configuration works, use `fusion-research` with `mcp_fusion_search_framework` to get source-backed evidence before implementing.
+
+Example query: `mcp_fusion_search_framework` → `"IModule initialize configure AppModuleInitiator custom module"`

--- a/skills/fusion-developer-app/references/using-custom-modules.md
+++ b/skills/fusion-developer-app/references/using-custom-modules.md
@@ -24,6 +24,8 @@ Every custom module must implement the `IModule` interface from `@equinor/fusion
 ```typescript
 import type { IModule } from '@equinor/fusion-framework-module';
 
+export const MODULE_NAME = 'myModule' as const; // Unique module key — must not conflict with built-in modules
+
 export interface IMyModuleConfig {
   // Configuration shape for your module
   apiBaseUrl: string;
@@ -35,7 +37,7 @@ export interface IMyModule {
 }
 
 export const module: IModule<IMyModule, IMyModuleConfig> = {
-  name: 'myModule', // Unique module key — must not conflict with built-in modules
+  name: MODULE_NAME,
   initialize: async ({ config, instance }): Promise<IMyModule> => {
     const cfg = await config;
     const client = new MyApiClient(cfg.apiBaseUrl);
@@ -72,10 +74,11 @@ Use `useAppModule` from `@equinor/fusion-framework-react-app` with the module na
 ```typescript
 import { useAppModule } from '@equinor/fusion-framework-react-app';
 import type { IMyModule } from '../modules/myModule';
+import { MODULE_NAME } from '../modules/myModule';
 
 const MyFeatureComponent = () => {
   // Type the module by its interface
-  const myModule = useAppModule<IMyModule>('myModule');
+  const myModule = useAppModule<IMyModule>(MODULE_NAME);
   const client = myModule.getClient();
 
   // Use the client in a React Query hook or useEffect

--- a/skills/fusion-developer-app/references/using-custom-modules.md
+++ b/skills/fusion-developer-app/references/using-custom-modules.md
@@ -104,14 +104,14 @@ src/
     myModule/
       index.ts       — module definition + exports
       MyApiClient.ts — implementation
-  config.ts          — registermodule here
+  config.ts          — register module here
 ```
 
 ## Common pitfalls
 
 - **Naming conflicts**: the module `name` must not collide with built-in Fusion module names (`http`, `auth`, `context`, `navigation`, `featureFlag`, `settings`, `bookmarks`, `analytics`). Use a unique name specific to your app or domain.
 - **Accessing modules outside React**: `useAppModule` is a hook and cannot be called outside components. For route loaders or non-React contexts, access the framework instance directly via `framework.modules.<name>`.
-- **Config not awaited**: the `initialize` callback receives a `Promise<config>` — always `await config` before reading config values.
+- **Config not awaited**: the `initialize` callback receives a `Promise<IMyModuleConfig>` — always `await config` before reading config values.
 - **Over-engineering**: if only one component needs the behavior, a hook or React context is simpler. Use a module when multiple disconnected parts of the app share the same infrastructure.
 
 ## When to use `fusion-research` first


### PR DESCRIPTION
## Why

`fusion-developer-app` lacked guidance on authoring custom Fusion Framework modules — a common pattern when teams need shared, cross-cutting infrastructure (custom service clients, shared subscriptions) wired into the app bootstrap lifecycle.

## Current behavior

No custom module reference. Developers have no in-skill guidance on the `IModule` contract, how to wire a module into `config.ts`, or how to access it via `useAppModule`.

## New behavior

New reference `references/using-custom-modules.md` covering:
- When to use a custom module vs React context or a plain hook
- `IModule` interface and `initialize` callback
- Wiring via `AppModuleInitiator` / `configurator.addModule` in `config.ts`
- Accessing with `useAppModule<IMyModule>('name')`
- Module lifecycle (initialize → access → no auto-destroy)
- File structure convention
- Common pitfalls (naming conflicts, calling hooks outside React, un-awaited config, over-engineering)

`SKILL.md` updated with custom-module activation triggers and a new row in the Step 6 module table.

## References

- Issue(s): Resolves equinor/fusion-core-tasks#753
- Related PR(s): —
- Docs / specs: [Fusion Framework modules](https://equinor.github.io/fusion-framework/)

## Reviewer focus

- Start here: `skills/fusion-developer-app/references/using-custom-modules.md`
- Verify these behavior changes: `IModule` interface and `useAppModule` usage are consistent with `@equinor/fusion-framework-module` and `@equinor/fusion-framework-react-app` APIs; pitfall list is accurate
- Risky or security-sensitive parts: none

## Self review checklist

- [x] I scoped this PR to one clear purpose.
- [x] I followed [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I did not include secrets, credentials, or sensitive data.
- [x] I reviewed my own diff for clarity and unintended changes.
