### PR TITLE
feat(fusion-devtools): add skill for Fusion DevTools CLI (fdev)

### DIFF
--- a/.changeset/add-fusion-devtools-skill.md
+++ b/.changeset/add-fusion-devtools-skill.md
@@ -1,0 +1,7 @@
+---
+"fusion-devtools": minor
+---
+
+Add fusion-devtools skill for Fusion DevTools CLI (fdev)
+
+Covers REST API calls, token acquisition, service discovery, person lookup, PIM activation, and environment mapping.

--- a/.changeset/backend-dev-add-devtools-dep.md
+++ b/.changeset/backend-dev-add-devtools-dep.md
@@ -1,0 +1,5 @@
+---
+"fusion-backend-dev": patch
+---
+
+Add fusion-devtools to skill dependencies

--- a/skills/fusion-backend-dev/SKILL.md
+++ b/skills/fusion-backend-dev/SKILL.md
@@ -10,6 +10,7 @@ metadata:
   skills:
     - fusion-research
     - fusion-code-conventions
+    - fusion-devtools
   tags:
     - fusion-backend
     - api-consumption

--- a/skills/fusion-devtools/SKILL.md
+++ b/skills/fusion-devtools/SKILL.md
@@ -130,7 +130,7 @@ Output format:
 {
   "accessToken": "eyJ...",
   "expiresOn": "2026-05-15T12:00:00+00:00",
-  "expiresOnUnix": 1778990400,
+  "expiresOnUnix": 1747310400,
   "scope": "api://app-id/.default",
   "tokenType": "Bearer"
 }
@@ -159,7 +159,17 @@ fdev persons resolve user@equinor.com
 fdev persons search "John"
 ```
 
-### 5 — Get a raw JWT token (clipboard)
+### 5 — Activate PIM role
+
+Elevate Azure access when needed for admin operations:
+
+```bash
+fdev pim azure activate
+```
+
+**Safety: always confirm with the user before running PIM activation — this grants elevated access.**
+
+### 6 — Get a raw JWT token (clipboard)
 
 For quick clipboard-based token workflows (existing command):
 
@@ -214,7 +224,6 @@ fdev rest people '/persons/me?api-version=3.0' --no-cache
 | `ci` | Continuous integration / development | Least stable, latest changes |
 | `fqa` | Quality assurance | Pre-production validation |
 | `fprd` | Production | Default environment |
-| `pr-<number>` | Pull request preview | Ephemeral, created per PR |
 
 Default environment is `fprd` for all commands. Override with `-e <env>`.
 
@@ -224,16 +233,6 @@ See `references/` for detailed command options and workflow recipes:
 
 - `command-reference.md` — compact command cheat sheet with all options
 - `agentic-patterns.md` — common agentic workflow recipes
-
-### 6 — Activate PIM role
-
-Elevate Azure access when needed for admin operations:
-
-```bash
-fdev pim azure activate
-```
-
-**Safety: always confirm with the user before running PIM activation — this grants elevated access.**
 
 ## Safety
 

--- a/skills/fusion-devtools/SKILL.md
+++ b/skills/fusion-devtools/SKILL.md
@@ -3,7 +3,8 @@ name: fusion-devtools
 description: 'Use Fusion DevTools CLI (fdev) for API testing, token acquisition, service discovery, and person lookup during development. USE FOR: calling Fusion REST APIs, getting access tokens as JSON, discovering services and environments, resolving persons, PIM role activation. DO NOT USE FOR: modifying backend service code, deploying services, infrastructure changes, CI/CD pipeline configuration, or Service Bus operations.'
 license: MIT
 compatibility: >
-  Requires fdev installed as a .NET global tool (dotnet tool install --global fusion-devtools).
+  Requires fdev installed as a .NET global tool
+  (dotnet tool install --global --add-source "https://statoil-proview.pkgs.visualstudio.com/Fusion%20-%20Packages/_packaging/Fusion-Public/nuget/v3/index.json" fusion-devtools).
   Requires Azure AD login (fdev login).
   Works best alongside fusion-backend-dev for understanding API contracts before calling them.
 metadata:
@@ -130,7 +131,7 @@ Output format:
 {
   "accessToken": "eyJ...",
   "expiresOn": "2026-05-15T12:00:00+00:00",
-  "expiresOnUnix": 1747310400,
+  "expiresOnUnix": 1778846400,
   "scope": "api://app-id/.default",
   "tokenType": "Bearer"
 }
@@ -143,6 +144,7 @@ Output format:
 fdev disc envs
 
 # List services in an environment (JSON output)
+# Note: disc subcommand uses single-dash flags (-json, -out) — this is by design
 fdev disc env list fprd -json
 
 # List services showing key and URI
@@ -197,7 +199,7 @@ If not installed, show the install command from Prerequisites. If authentication
 | Call a Fusion API and see the response | `fdev rest <service> '<path>'` |
 | Get a token for scripting/piping | `fdev get-access-token --service-key <key>` |
 | Find available services | `fdev disc env list <env>` |
-| Find service base URL and scope | `fdev disc env list <env> -json \| jq '.[] \| select(.key=="<key>")'` |
+| Find service base URL and scope | `fdev disc env list <env> -json` then filter by key |
 | Look up a person | `fdev persons resolve <email>` |
 | Quick clipboard token | `fdev token` |
 
@@ -236,6 +238,7 @@ See `references/` for detailed command options and workflow recipes:
 
 ## Safety
 
+- This skill is mutation-capable. Repository-local workflow instructions take precedence over inline guidance when they conflict.
 - Never expose raw access tokens in output shown to users — truncate or redact when displaying
 - Always quote paths containing `?` in shell commands to prevent glob expansion
 - Use `--no-auth` only for genuinely public endpoints

--- a/skills/fusion-devtools/SKILL.md
+++ b/skills/fusion-devtools/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: fusion-devtools
+description: 'Use Fusion DevTools CLI (fdev) for API testing, token acquisition, service discovery, and person lookup during development. USE FOR: calling Fusion REST APIs, getting access tokens as JSON, discovering services and environments, resolving persons, managing access roles, triggering Azure Functions. DO NOT USE FOR: modifying backend service code, deploying services, infrastructure changes, CI/CD pipeline configuration, or Service Bus operations.'
+license: MIT
+compatibility: >
+  Requires fdev installed as a .NET global tool (dotnet tool install --global fusion-devtools).
+  Requires Azure AD login (fdev login).
+  Works best alongside fusion-backend-dev for understanding API contracts before calling them.
+metadata:
+  version: "0.0.0"
+  status: active
+  owner: "@equinor/fusion-core"
+  tags:
+    - fusion
+    - devtools
+    - cli
+    - rest-api
+    - token
+    - service-discovery
+    - debugging
+    - testing
+---
+
+# Fusion DevTools
+
+## When to use
+
+Use when you need to interact with Fusion platform services from the command line — calling APIs, getting tokens, discovering services, or looking up persons.
+
+Typical triggers:
+- "Call the People API"
+- "Get a token for the context service"
+- "Which services are available in production?"
+- "Test this endpoint"
+- "Resolve this person's Azure ID"
+- "What's the base URL for the org service?"
+- "Get me an access token I can pipe to jq"
+
+Implicit triggers:
+- Agent needs to verify an API contract or response shape
+- Agent needs a bearer token for an HTTP request
+- Agent needs to find which service key maps to a URL
+- Agent needs to look up a person's identity for test data
+
+## When not to use
+
+- Modifying backend service source code — use the service repo directly
+- Deploying or publishing services — use CI/CD pipelines
+- Infrastructure provisioning — use Terraform/Bicep
+- Service Bus / SignalR debugging — use Azure portal or dedicated tooling
+- Managing AI search indexes — separate ops concern
+
+## Prerequisites
+
+Install fdev as a .NET global tool:
+
+```bash
+dotnet tool install --global --add-source "https://statoil-proview.pkgs.visualstudio.com/Fusion%20-%20Packages/_packaging/Fusion-Public/nuget/v3/index.json" fusion-devtools
+```
+
+Update to latest:
+
+```bash
+dotnet tool update --global --add-source "https://statoil-proview.pkgs.visualstudio.com/Fusion%20-%20Packages/_packaging/Fusion-Public/nuget/v3/index.json" fusion-devtools
+```
+
+Authenticate before first use:
+
+```bash
+fdev login
+```
+
+## Core workflows
+
+### 1 — Call a Fusion REST API
+
+Use `fdev rest` to call any Fusion service. Service discovery resolves the base URL and acquires a token automatically.
+
+```bash
+fdev rest <serviceKey> '<path>'
+```
+
+The path must be quoted in zsh/bash to prevent `?` glob expansion.
+
+**Examples:**
+
+```bash
+# GET from people service (production)
+fdev rest people '/persons/me?api-version=3.0'
+
+# POST with JSON body
+fdev rest context '/contexts?api-version=1.0' -m post -b '{"query":"test"}'
+
+# POST with body from file
+fdev rest people '/persons/search?api-version=3.0' -m post -b @request.json
+
+# Different environment
+fdev rest people '/persons/me?api-version=3.0' -e ci
+
+# Save response to file
+fdev rest people '/persons/me?api-version=3.0' -o response.json
+
+# Full URL mode (skip discovery)
+fdev rest --url https://httpbin.org/get --no-auth
+
+# Custom scope override
+fdev rest people '/persons/me?api-version=3.0' --scope api://my-app/.default
+```
+
+Key options: `-m` method, `-b` body (`@file` supported), `-e` environment, `--url` full URL mode, `--no-auth` skip auth, `--scope` override scope, `-o` output file, `--header KEY=VALUE`.
+
+### 2 — Get an access token
+
+Use `fdev get-access-token` for structured JSON token output, similar to `az account get-access-token`. Output is pipe-friendly.
+
+```bash
+# Token for a specific service (resolves scope via discovery)
+fdev get-access-token --service-key people
+
+# Token with explicit scope
+fdev get-access-token --scope api://97978493-9777-4d48-b38a-67b0b9cd88d2/.default
+
+# Extract just the token
+fdev get-access-token --service-key people | jq -r '.accessToken'
+```
+
+Output format:
+
+```json
+{
+  "accessToken": "eyJ...",
+  "expiresOn": "2026-05-15T12:00:00+00:00",
+  "expiresOnUnix": 1736942400,
+  "scope": "api://app-id/.default",
+  "tokenType": "Bearer"
+}
+```
+
+### 3 — Discover services and environments
+
+```bash
+# List all environments
+fdev disc envs
+
+# List services in an environment (JSON output)
+fdev disc env list fprd -json
+
+# List services showing key and URI
+fdev disc env list fprd -out ku
+```
+
+### 4 — Look up a person
+
+```bash
+# Resolve by email
+fdev persons resolve user@equinor.com
+
+# Search by name
+fdev persons search "John"
+```
+
+### 5 — Get a raw JWT token (clipboard)
+
+For quick clipboard-based token workflows (existing command):
+
+```bash
+fdev token          # test environment token
+fdev token --prod   # production token
+```
+
+## Instructions
+
+### Step 1 — Confirm fdev is available
+
+Before using any fdev command, verify it is installed:
+
+```bash
+fdev --version
+```
+
+If not installed, show the install command from Prerequisites. If authentication is needed, run `fdev login`.
+
+### Step 2 — Choose the right command
+
+| Need | Command |
+|---|---|
+| Call a Fusion API and see the response | `fdev rest <service> '<path>'` |
+| Get a token for scripting/piping | `fdev get-access-token --service-key <key>` |
+| Find available services | `fdev disc env list <env>` |
+| Find service base URL and scope | `fdev disc env list <env> -json \| jq '.[] \| select(.key=="<key>")'` |
+| Look up a person | `fdev persons resolve <email>` |
+| Quick clipboard token | `fdev token` |
+
+### Step 3 — Use verbose mode for debugging
+
+Add `--verbose` to any command for diagnostic output including cache hit/miss, full request/response headers, and token details.
+
+```bash
+fdev rest people '/persons/me?api-version=3.0' --verbose
+```
+
+### Step 4 — Bypass cache when needed
+
+Service discovery results are cached locally (environments: 24h, services: 1h). Use `--no-cache` to force fresh lookups:
+
+```bash
+fdev rest people '/persons/me?api-version=3.0' --no-cache
+```
+
+## Environments
+
+| Key | Purpose | Notes |
+|---|---|---|
+| `ci` | Continuous integration / development | Least stable, latest changes |
+| `fqa` | Quality assurance | Pre-production validation |
+| `fprd` | Production | Default environment |
+| `pr-<number>` | Pull request preview | Ephemeral, created per PR |
+
+Default environment is `fprd` for all commands. Override with `-e <env>`.
+
+## Reference guides
+
+See `references/` for detailed command options and workflow recipes:
+
+- `command-reference.md` — compact command cheat sheet with all options
+- `agentic-patterns.md` — common agentic workflow recipes
+
+## Safety
+
+- Never expose raw access tokens in output shown to users — truncate or redact when displaying
+- Always quote paths containing `?` in shell commands to prevent glob expansion
+- Use `--no-auth` only for genuinely public endpoints
+- Confirm with the user before running `fdev pim azure activate` (elevated access)
+- Do not store or log tokens to files unless explicitly requested

--- a/skills/fusion-devtools/SKILL.md
+++ b/skills/fusion-devtools/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fusion-devtools
-description: 'Use Fusion DevTools CLI (fdev) for API testing, token acquisition, service discovery, and person lookup during development. USE FOR: calling Fusion REST APIs, getting access tokens as JSON, discovering services and environments, resolving persons, managing access roles, triggering Azure Functions. DO NOT USE FOR: modifying backend service code, deploying services, infrastructure changes, CI/CD pipeline configuration, or Service Bus operations.'
+description: 'Use Fusion DevTools CLI (fdev) for API testing, token acquisition, service discovery, and person lookup during development. USE FOR: calling Fusion REST APIs, getting access tokens as JSON, discovering services and environments, resolving persons, PIM role activation. DO NOT USE FOR: modifying backend service code, deploying services, infrastructure changes, CI/CD pipeline configuration, or Service Bus operations.'
 license: MIT
 compatibility: >
   Requires fdev installed as a .NET global tool (dotnet tool install --global fusion-devtools).
@@ -130,7 +130,7 @@ Output format:
 {
   "accessToken": "eyJ...",
   "expiresOn": "2026-05-15T12:00:00+00:00",
-  "expiresOnUnix": 1736942400,
+  "expiresOnUnix": 1778990400,
   "scope": "api://app-id/.default",
   "tokenType": "Bearer"
 }
@@ -224,6 +224,16 @@ See `references/` for detailed command options and workflow recipes:
 
 - `command-reference.md` — compact command cheat sheet with all options
 - `agentic-patterns.md` — common agentic workflow recipes
+
+### 6 — Activate PIM role
+
+Elevate Azure access when needed for admin operations:
+
+```bash
+fdev pim azure activate
+```
+
+**Safety: always confirm with the user before running PIM activation — this grants elevated access.**
 
 ## Safety
 

--- a/skills/fusion-devtools/references/agentic-patterns.md
+++ b/skills/fusion-devtools/references/agentic-patterns.md
@@ -1,0 +1,117 @@
+# Agentic workflow patterns
+
+Common recipes for coding agents using fdev in automated workflows.
+
+## Pattern 1 — Verify API response shape
+
+When an agent needs to confirm the actual response structure from a Fusion API:
+
+```bash
+# Fetch a real response and inspect its structure
+fdev rest people '/persons/me?api-version=3.0' | jq 'keys'
+
+# Get full response with headers for debugging
+fdev rest people '/persons/me?api-version=3.0' --verbose
+```
+
+Use case: before generating client code or types, verify the actual API contract matches expectations.
+
+## Pattern 2 — Get a token for external tools
+
+When an agent needs a bearer token to pass to curl, httpie, or another HTTP client:
+
+```bash
+# Extract token for use in other commands
+TOKEN=$(fdev get-access-token --service-key people | jq -r '.accessToken')
+
+# Use with curl
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://pro-s-people-fprd.azurewebsites.net/persons/me?api-version=3.0"
+```
+
+Use case: agent needs to call an endpoint not yet in service discovery, or needs fine-grained control over the HTTP request.
+
+## Pattern 3 — Discover service base URL
+
+When an agent needs to construct URLs for documentation or configuration:
+
+```bash
+# Find the base URL for a service
+fdev disc env list fprd -json | jq '.[] | select(.key=="people") | .uri'
+
+# List all service keys
+fdev disc env list fprd -json | jq '.[].key'
+```
+
+Use case: generating app.config.ts service client registrations, updating documentation with correct endpoints.
+
+## Pattern 4 — Resolve person identity
+
+When an agent needs a person's Azure Object ID for test data or API calls:
+
+```bash
+# Resolve email to person details
+fdev persons resolve user@equinor.com
+
+# Search by name when email is unknown
+fdev persons search "John Smith"
+```
+
+Use case: setting up test fixtures, looking up managers/owners, populating request bodies that require person identifiers.
+
+## Pattern 5 — Test across environments
+
+When validating that an API behaves consistently across environments:
+
+```bash
+# Compare responses across environments
+fdev rest people '/persons/me?api-version=3.0' -e ci
+fdev rest people '/persons/me?api-version=3.0' -e fqa
+fdev rest people '/persons/me?api-version=3.0' -e fprd
+```
+
+Use case: debugging environment-specific issues, verifying deployments.
+
+## Pattern 6 — POST with request body from file
+
+When an agent generates a request payload and needs to send it:
+
+```bash
+# Write payload to temp file, then send
+cat > /tmp/search.json << 'EOF'
+{
+  "searchString": "test",
+  "top": 5
+}
+EOF
+
+fdev rest people '/persons/search?api-version=3.0' -m post -b @/tmp/search.json
+```
+
+Use case: complex request bodies that are easier to construct as files than inline JSON.
+
+## Pattern 7 — Chain discovery with token for scripting
+
+Full scripted flow: discover service, get token, make authenticated calls:
+
+```bash
+# Get service info as JSON
+SERVICE_INFO=$(fdev disc env list fprd -json | jq '.[] | select(.key=="org")')
+BASE_URL=$(echo "$SERVICE_INFO" | jq -r '.uri')
+
+# Get token for that service
+TOKEN=$(fdev get-access-token --service-key org | jq -r '.accessToken')
+
+# Make multiple calls with the same token
+curl -s -H "Authorization: Bearer $TOKEN" "$BASE_URL/projects?api-version=3.0" | jq '.value | length'
+```
+
+Use case: batch operations, scripted validation, integration testing.
+
+## Safety reminders
+
+- **Redact tokens**: when showing output to users, truncate or mask `accessToken` values
+- **Quote paths**: always single-quote paths containing `?` or `&` to prevent shell expansion
+- **Confirm PIM**: ask user before running `fdev pim azure activate`
+- **Prefer --service-key**: over hardcoded scopes — service keys adapt to environment changes
+- **Use --verbose**: for debugging, not in final agent output — it contains sensitive headers

--- a/skills/fusion-devtools/references/agentic-patterns.md
+++ b/skills/fusion-devtools/references/agentic-patterns.md
@@ -20,8 +20,10 @@ Use case: before generating client code or types, verify the actual API contract
 
 When an agent needs a bearer token to pass to curl, httpie, or another HTTP client:
 
+> Prefer `fdev rest` with `--url` when possible — it handles tokens internally without exposing them. Use the variable approach only when another tool must make the HTTP call.
+
 ```bash
-# Extract token for use in other commands
+# Extract token for use in other commands (short-lived, local shell variable only)
 TOKEN=$(fdev get-access-token --service-key people | jq -r '.accessToken')
 BASE_URL=$(fdev disc env list fprd -json | jq -r '.[] | select(.key=="people") | .uri')
 

--- a/skills/fusion-devtools/references/agentic-patterns.md
+++ b/skills/fusion-devtools/references/agentic-patterns.md
@@ -23,10 +23,10 @@ When an agent needs a bearer token to pass to curl, httpie, or another HTTP clie
 ```bash
 # Extract token for use in other commands
 TOKEN=$(fdev get-access-token --service-key people | jq -r '.accessToken')
+BASE_URL=$(fdev disc env list fprd -json | jq -r '.[] | select(.key=="people") | .uri')
 
 # Use with curl
-curl -H "Authorization: Bearer $TOKEN" \
-  "https://pro-s-people-fprd.azurewebsites.net/persons/me?api-version=3.0"
+curl -H "Authorization: Bearer $TOKEN" "$BASE_URL/persons/me?api-version=3.0"
 ```
 
 Use case: agent needs to call an endpoint not yet in service discovery, or needs fine-grained control over the HTTP request.
@@ -77,15 +77,17 @@ Use case: debugging environment-specific issues, verifying deployments.
 When an agent generates a request payload and needs to send it:
 
 ```bash
-# Write payload to temp file, then send
-cat > /tmp/search.json << 'EOF'
+# Write payload to temp file, send, then clean up
+TMPFILE=$(mktemp /tmp/fdev-body.XXXXXX.json)
+cat > "$TMPFILE" << 'EOF'
 {
   "searchString": "test",
   "top": 5
 }
 EOF
 
-fdev rest people '/persons/search?api-version=3.0' -m post -b @/tmp/search.json
+fdev rest people '/persons/search?api-version=3.0' -m post -b @"$TMPFILE"
+rm -f "$TMPFILE"
 ```
 
 Use case: complex request bodies that are easier to construct as files than inline JSON.

--- a/skills/fusion-devtools/references/command-reference.md
+++ b/skills/fusion-devtools/references/command-reference.md
@@ -1,0 +1,105 @@
+# Command reference
+
+Compact reference for all fdev commands relevant to agentic workflows.
+
+## Authentication
+
+```bash
+fdev login                    # Interactive Azure AD login (browser)
+fdev login --client-secret    # Service principal login
+```
+
+## REST API calls
+
+```bash
+fdev rest <serviceKey> '<path>' [options]
+fdev rest --url <fullUrl> [options]
+```
+
+| Option | Short | Description |
+|---|---|---|
+| `--method` | `-m` | HTTP method (GET, POST, PUT, PATCH, DELETE). Default: GET |
+| `--body` | `-b` | Request body. Prefix with `@` for file: `-b @body.json` |
+| `--header` | | Add header: `--header Content-Type=application/xml` |
+| `--env` | `-e` | Environment: ci, fqa, fprd (default: fprd) |
+| `--scope` | | Override OAuth scope |
+| `--url` | | Full URL mode (skip service discovery) |
+| `--no-auth` | | Skip token acquisition |
+| `--token` | | Use a specific bearer token |
+| `--output-file` | `-o` | Save response body to file |
+| `--verbose` | | Show request/response headers and cache diagnostics |
+| `--no-cache` | | Bypass service discovery cache |
+
+## Token acquisition
+
+```bash
+fdev get-access-token [options]
+```
+
+| Option | Description |
+|---|---|
+| `--service-key` | Resolve scope from service discovery (e.g. `people`, `context`, `org`) |
+| `--scope` | Explicit OAuth scope |
+| `--env` | Environment for service key resolution (default: fprd) |
+
+Output: JSON with `accessToken`, `expiresOn`, `expiresOnUnix`, `scope`, `tokenType`.
+
+```bash
+fdev token [--prod]           # Quick token to clipboard (test env default)
+```
+
+## Service discovery
+
+```bash
+fdev disc envs                         # List environments
+fdev disc env list <env>               # List services in environment
+fdev disc env list <env> -json         # JSON output
+fdev disc env list <env> -out ku       # Show key + URI columns
+```
+
+## Person resolution
+
+```bash
+fdev persons resolve <email>           # Resolve by email or UPN
+fdev persons search "<name>"           # Search by name
+```
+
+## PIM access elevation
+
+```bash
+fdev pim azure activate               # Activate eligible Azure PIM role
+```
+
+**Safety: always confirm with user before running PIM activation.**
+
+## Common service keys
+
+| Key | Service | Typical path prefix |
+|---|---|---|
+| `people` | People / Persons API | `/persons/` |
+| `context` | Context API | `/contexts/` |
+| `org` | Org / Positions API | `/projects/` or `/positions/` |
+| `notifications` | Notifications API | `/persons/{id}/notifications/` |
+| `reports` | Reports API | `/reports/` |
+| `tasks` | Tasks API | `/tasks/` |
+| `apps` | Apps / Bundles API | `/apps/` or `/bundles/` |
+| `bookmarks` | Bookmarks API | `/persons/{id}/bookmarks/` |
+| `roles` | Roles API | `/roles/` |
+
+Use `fdev disc env list fprd -json | jq '.[].key'` to get the full list of service keys for an environment.
+
+## Environment mapping
+
+| fdev env key | Azure environment | Portal URL |
+|---|---|---|
+| `ci` | Test / Development | `https://fusion.ci.fusion-dev.net` |
+| `fqa` | QA / Pre-production | `https://fusion.fqa.fusion-dev.net` |
+| `fprd` | Production | `https://fusion.equinor.com` |
+| `pr-<n>` | PR preview (ephemeral) | Varies |
+
+## Global options
+
+| Option | Description |
+|---|---|
+| `--verbose` | Verbose output (cache diagnostics, request details) |
+| `--no-cache` | Bypass SQLite cache for service discovery |

--- a/skills/fusion-devtools/references/command-reference.md
+++ b/skills/fusion-devtools/references/command-reference.md
@@ -72,7 +72,9 @@ fdev pim azure activate               # Activate eligible Azure PIM role
 
 **Safety: always confirm with user before running PIM activation.**
 
-## Common service keys
+## Common service keys (examples — verify with discovery)
+
+These are typical service keys. Keys may change as services are added, renamed, or retired. Always verify with `fdev disc env list <env> -json | jq '.[].key'`.
 
 | Key | Service | Typical path prefix |
 |---|---|---|

--- a/skills/fusion-devtools/references/command-reference.md
+++ b/skills/fusion-devtools/references/command-reference.md
@@ -97,7 +97,6 @@ Use `fdev disc env list fprd -json | jq '.[].key'` to get the full list of servi
 | `ci` | Test / Development | `https://fusion.ci.fusion-dev.net` |
 | `fqa` | QA / Pre-production | `https://fusion.fqa.fusion-dev.net` |
 | `fprd` | Production | `https://fusion.equinor.com` |
-| `pr-<n>` | PR preview (ephemeral) | Varies |
 
 ## Global options
 


### PR DESCRIPTION
## Why

Agents working with Fusion backend APIs need a structured way to call REST endpoints, acquire tokens, and discover services. The `fdev` CLI already supports these workflows, but without a skill, agents don't know it exists or how to use it correctly.

## Current behavior

No skill exists for the Fusion DevTools CLI. Agents that need to test API endpoints or get tokens must be manually guided through `fdev` commands, or fall back to raw `curl` with hardcoded URLs and manual token management.

## New behavior

- New `fusion-devtools` skill covering REST API calls, token acquisition, service discovery, person lookup, and environment mapping.
- Reference guides for compact command options and 7 common agentic workflow patterns.
- `fusion-backend-dev` now lists `fusion-devtools` as a dependency, so agents exploring backend APIs can discover fdev workflows automatically.

## References

- Related PR(s): https://github.com/equinor/fusion-dev-tools/pull/200 (adds `fdev rest` and `fdev get-access-token` commands)

## Reviewer focus

- Start here (files/areas): `skills/fusion-devtools/SKILL.md`
- Verify these behavior changes: `fusion-backend-dev` skill now references `fusion-devtools` in its `metadata.skills` list
- Risky or security-sensitive parts: Safety section in SKILL.md covers token redaction and PIM confirmation gates

## Self review checklist

- [x] I scoped this PR to one clear purpose.
- [x] I followed [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I did not include secrets, credentials, or sensitive data.
- [x] I reviewed my own diff for clarity and unintended changes.
