### PR TITLE
feat(fusion-design): add experimental design skill draft + fusion-developer-app design agent

### DIFF
--- a/.changeset/add-fusion-design-skill.md
+++ b/.changeset/add-fusion-design-skill.md
@@ -1,0 +1,9 @@
+---
+"fusion-design": minor
+---
+
+Add experimental `fusion-design` skill
+
+New skill that looks up Fusion Design Guidelines and applies them to frontend code in the Fusion ecosystem. Covers layout, spacing, component usage, and interaction patterns. Supports app-local `DESIGN.md` overrides.
+
+ref equinor/fusion-skills#860

--- a/.changeset/add-fusion-design-skill.md
+++ b/.changeset/add-fusion-design-skill.md
@@ -6,4 +6,4 @@ Add experimental `fusion-design` skill
 
 New skill that looks up Fusion Design Guidelines and applies them to frontend code in the Fusion ecosystem. Covers layout, spacing, component usage, and interaction patterns. Supports app-local `DESIGN.md` overrides.
 
-ref equinor/fusion-skills#860
+Refs: equinor/fusion-core-tasks#860

--- a/skills/.experimental/fusion-design/SKILL.md
+++ b/skills/.experimental/fusion-design/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: fusion-design
+description: 'Looks up Fusion Design Guidelines and applies them to any frontend code in the Fusion ecosystem. USE FOR: layout, spacing, component usage, interaction patterns, any UI implementation decision. DO NOT USE FOR: backend changes, CI/CD, skill authoring, data layer logic.'
+license: MIT
+metadata:
+  version: "0.0.0"
+  tags:
+    - design
+    - fusion-framework
+    - layout
+---
+
+# Fusion Design
+
+## When to use
+
+Any time you are writing or reviewing frontend code in the Fusion ecosystem and need to know how it should look, behave, or be structured.
+
+## Instructions
+
+This skill is a lookup. Read the relevant reference file, then apply the rules.
+
+### 1. Read the references
+
+> **Note:** Reference files are not yet published. This section will be populated once `references/` is committed.
+
+### 2. Check for a local `DESIGN.md`
+
+If the app has a `DESIGN.md` at its root, read it first. It is the authoritative source for that app's design decisions and overrides or supplements the reference rules.
+
+### 3. Apply
+
+Implement the UI to match the rules. If no `DESIGN.md` exists and the task requires a layout decision, document it there.

--- a/skills/.experimental/fusion-design/SKILL.md
+++ b/skills/.experimental/fusion-design/SKILL.md
@@ -4,6 +4,8 @@ description: 'Looks up Fusion Design Guidelines and applies them to any frontend
 license: MIT
 metadata:
   version: "0.0.0"
+  status: experimental
+  owner: "@equinor/fusion-core"
   tags:
     - design
     - fusion-framework

--- a/skills/fusion-developer-app/agents/design.md
+++ b/skills/fusion-developer-app/agents/design.md
@@ -15,8 +15,8 @@ Design ground truth comes from `equinor-design-system` system skill. When instal
 
 ## MCP tooling
 
-- Use **`mcp_fusion_search_eds`** for EDS component questions: tokens, props, usage examples, and layout primitives (e.g. `Typography`, `Button`, `Icon`, `Progress`).
-- Use **`mcp_fusion_search_framework`** for Fusion Portal shell/Fusion-specific component questions (e.g. `SideSheet`, `TopBar`, navigation zones, how portal wraps the app).
+- Use **`mcp_fusion_search_eds`** for EDS component questions: tokens, props, usage examples, and layout primitives (e.g. `Typography`, `Button`, `Icon`, `Progress`, `TopBar`).
+- Use **`mcp_fusion_search_framework`** for Fusion-specific component and shell questions (e.g. `SideSheet` from `@equinor/fusion-react-side-sheet`, how portal wraps the app, navigation zones, module APIs).
 
 ## Process
 

--- a/skills/fusion-developer-app/agents/design.md
+++ b/skills/fusion-developer-app/agents/design.md
@@ -15,8 +15,8 @@ Design ground truth comes from `equinor-design-system` system skill. When instal
 
 ## MCP tooling
 
-- Use **`mcp_fusion_search_framework`** for Fusion Portal shell/module questions (e.g. `SideSheet`, `TopBar`, navigation zones, how portal wraps the app).
-- Use **`mcp_fusion_search_eds`** for EDS layout primitives and design token lookups.
+- Use **`mcp_fusion_search_eds`** for EDS component questions: tokens, props, usage examples, and layout primitives (e.g. `Typography`, `Button`, `Icon`, `Progress`).
+- Use **`mcp_fusion_search_framework`** for Fusion Portal shell/Fusion-specific component questions (e.g. `SideSheet`, `TopBar`, navigation zones, how portal wraps the app).
 
 ## Process
 
@@ -47,12 +47,12 @@ Verify layout follows three-zone convention from `equinor-design-system`:
 |---|---|---|
 | Main content | `<main>` or app root `<div>` spanning full available area | Custom flexbox wrapper that clips or limits available height |
 | Side panel | `@equinor/fusion-react-side-sheet` | Custom `position: fixed` or `position: absolute` right panel |
-| Spacing | `--eds-spacing-*` tokens | Arbitrary `margin: 24px`, `padding: 16px` raw pixel values |
+| Spacing | `--eds-spacing-*` / `--eds-container-space-*` tokens | Arbitrary `margin: 24px`, `padding: 16px` raw pixel values |
 
-For spacing violations, identify specific token (refer to `equinor-design-system` spacing table):
-- `var(--eds-spacing-comfortable-x-small)` — tight gaps
-- `var(--eds-spacing-comfortable-medium)` — standard content padding
-- `var(--eds-spacing-comfortable-large)` — section separation
+For spacing violations, identify specific token (refer to `equinor-design-system` spacing table or `mcp_fusion_search_eds`):
+- `var(--eds-spacing-horizontal-sm)` / `var(--eds-spacing-vertical-sm)` — tight gaps (8px)
+- `var(--eds-container-space-horizontal)` / `var(--eds-container-space-vertical)` — container padding
+- `var(--eds-page-space-horizontal)` / `var(--eds-page-space-vertical)` — page-level padding
 
 ### Step 4: Check structural anti-patterns
 
@@ -60,7 +60,7 @@ Flag:
 
 - **Nested full-page scrollable containers** — page content wrapped in `overflow-y: auto` when browser scroll is intended. Deliberate AG Grid or fixed-height table regions are acceptable.
 - **Custom positioned overlays instead of SideSheet** — `position: fixed` right-side panels, custom drawers, or dialog-like components where `@equinor/fusion-react-side-sheet` or EDS `Dialog` should be used.
-- **Shadow or color outside EDS tokens** — raw `box-shadow`, hex codes, or named CSS colors instead of `--eds-elevation-*` and `--eds-color-*` tokens.
+- **Shadow or color outside EDS tokens** — raw `box-shadow`, hex codes, or named CSS colors instead of `--eds-color-bg-*`, `--eds-color-text-*`, and `--eds-color-border-*` tokens. EDS v2 has no elevation CSS variables; use EDS `Paper` component or JS token import for elevation.
 - **Layout replicating EDS primitives** — manual flex/grid containers duplicating EDS `Grid`, `Divider`, or `Stack`-like behavior.
 
 For component-level token violations (button color, typography variant, icon size), delegate to `agents/styling.md`.
@@ -71,7 +71,7 @@ Verify correct state patterns:
 
 | State | Expected pattern | Anti-pattern |
 |---|---|---|
-| Loading | EDS `Progress.Circular` or `Progress.Dots` — centered in content area | Blank screen, spinner in corner, or `display: none` |
+| Loading | EDS `Progress.Circular` or `Progress.Dots` (`import { Progress } from '@equinor/eds-core-react'`) — centered in content area | Blank screen, spinner in corner, or `display: none` |
 | Empty (no data) | `Typography` + optional primary action `Button` — centered or top-aligned | Omitted state (user sees nothing), custom illustration without text |
 | Error | `Typography` with danger semantic color + retry action | Raw `alert()`, uncaught exception, or blank component |
 

--- a/skills/fusion-developer-app/agents/design.md
+++ b/skills/fusion-developer-app/agents/design.md
@@ -15,8 +15,8 @@ Design ground truth comes from `equinor-design-system` system skill. When instal
 
 ## MCP tooling
 
-- Use **`mcp_fusion_search_eds`** for EDS component questions: tokens, props, usage examples, and layout primitives (e.g. `Typography`, `Button`, `Icon`, `Progress`, `TopBar`).
-- Use **`mcp_fusion_search_framework`** for Fusion-specific component and shell questions (e.g. `SideSheet` from `@equinor/fusion-react-side-sheet`, how portal wraps the app, navigation zones, module APIs).
+- Use **`mcp_fusion_search_framework`** for Fusion Portal shell/module questions (e.g. `SideSheet`, `TopBar`, navigation zones, how portal wraps the app).
+- Use **`mcp_fusion_search_eds`** for EDS layout primitives and design token lookups.
 
 ## Process
 
@@ -47,12 +47,12 @@ Verify layout follows three-zone convention from `equinor-design-system`:
 |---|---|---|
 | Main content | `<main>` or app root `<div>` spanning full available area | Custom flexbox wrapper that clips or limits available height |
 | Side panel | `@equinor/fusion-react-side-sheet` | Custom `position: fixed` or `position: absolute` right panel |
-| Spacing | `--eds-spacing-*` / `--eds-container-space-*` tokens | Arbitrary `margin: 24px`, `padding: 16px` raw pixel values |
+| Spacing | `--eds-spacing-*` tokens | Arbitrary `margin: 24px`, `padding: 16px` raw pixel values |
 
-For spacing violations, identify specific token (refer to `equinor-design-system` spacing table or `mcp_fusion_search_eds`):
-- `var(--eds-spacing-horizontal-sm)` / `var(--eds-spacing-vertical-sm)` — tight gaps (8px)
-- `var(--eds-container-space-horizontal)` / `var(--eds-container-space-vertical)` — container padding
-- `var(--eds-page-space-horizontal)` / `var(--eds-page-space-vertical)` — page-level padding
+For spacing violations, identify specific token (refer to `equinor-design-system` spacing table):
+- `var(--eds-spacing-comfortable-x-small)` — tight gaps
+- `var(--eds-spacing-comfortable-medium)` — standard content padding
+- `var(--eds-spacing-comfortable-large)` — section separation
 
 ### Step 4: Check structural anti-patterns
 
@@ -60,7 +60,7 @@ Flag:
 
 - **Nested full-page scrollable containers** — page content wrapped in `overflow-y: auto` when browser scroll is intended. Deliberate AG Grid or fixed-height table regions are acceptable.
 - **Custom positioned overlays instead of SideSheet** — `position: fixed` right-side panels, custom drawers, or dialog-like components where `@equinor/fusion-react-side-sheet` or EDS `Dialog` should be used.
-- **Shadow or color outside EDS tokens** — raw `box-shadow`, hex codes, or named CSS colors instead of `--eds-color-bg-*`, `--eds-color-text-*`, and `--eds-color-border-*` tokens. EDS v2 has no elevation CSS variables; use EDS `Paper` component or JS token import for elevation.
+- **Shadow or color outside EDS tokens** — raw `box-shadow`, hex codes, or named CSS colors instead of `--eds-elevation-*` and `--eds-color-*` tokens.
 - **Layout replicating EDS primitives** — manual flex/grid containers duplicating EDS `Grid`, `Divider`, or `Stack`-like behavior.
 
 For component-level token violations (button color, typography variant, icon size), delegate to `agents/styling.md`.
@@ -71,7 +71,7 @@ Verify correct state patterns:
 
 | State | Expected pattern | Anti-pattern |
 |---|---|---|
-| Loading | EDS `Progress.Circular` or `Progress.Dots` (`import { Progress } from '@equinor/eds-core-react'`) — centered in content area | Blank screen, spinner in corner, or `display: none` |
+| Loading | EDS `Progress.Circular` or `Progress.Dots` — centered in content area | Blank screen, spinner in corner, or `display: none` |
 | Empty (no data) | `Typography` + optional primary action `Button` — centered or top-aligned | Omitted state (user sees nothing), custom illustration without text |
 | Error | `Typography` with danger semantic color + retry action | Raw `alert()`, uncaught exception, or blank component |
 


### PR DESCRIPTION
## Why

`fusion-developer-app` lacked structured guidance on page and view composition: shell layout, zone nesting, side panel usage, and empty/loading/error state patterns. The existing `styling.md` agent covers component-level EDS usage but not layout structure.

Also adds an experimental `fusion-design` skill as a draft placeholder so the designer can continue iterating on design guidelines in their own repo without a full skill release.

## Current behavior

No design-structure agent. Developers have no in-skill guidance on how to compose Fusion Portal shell layouts, use side panels, or structure empty/loading states.

## New behavior

New helper agent `agents/design.md` covering:
- Shell composition and layout zone nesting
- `fusion-react-side-sheet` side panel usage
- Empty, loading, and error state patterns
- Structural anti-patterns
- Delegation to `equinor-design-system` for design token ground truth and to `styling.md` for component-level EDS checks

`SKILL.md` Step 4 updated to reference `design.md` for structure review and `styling.md` for component level.

New experimental skill `fusion-design` added under `skills/.experimental/` as a draft — `references/` not yet committed; the designer will populate it separately.

> **Note:** depends on `equinor-design-system` system skill (#859). Merge #859 before or alongside this PR.

## References

- Issue(s): Resolves equinor/fusion-core-tasks#860
- Related PR(s): equinor/fusion-skills#(#859 — equinor-design-system system skill, prerequisite)
- Docs / specs: [EDS documentation](https://eds.equinor.com/)

## Reviewer focus

- Start here: `skills/fusion-developer-app/agents/design.md`, `skills/.experimental/fusion-design/SKILL.md`
- Verify these behavior changes: design agent correctly delegates to `styling.md` for component EDS checks, does not duplicate component-level guidance
- Risky or security-sensitive parts: none

## Self review checklist

- [x] I scoped this PR to one clear purpose.
- [x] I followed [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I did not include secrets, credentials, or sensitive data.
- [x] I reviewed my own diff for clarity and unintended changes.
