### PR TITLE
feat: add EDS typography reference to fusion-design skill

### DIFF
--- a/.changeset/fusion-design-eds-typography-be9166ef.md
+++ b/.changeset/fusion-design-eds-typography-be9166ef.md
@@ -1,0 +1,8 @@
+---
+"fusion-design": patch
+---
+
+Add EDS typography reference
+
+- Add `references/eds-typography.md` with EDS typography rules
+- Update SKILL.md to list the reference and clarify all references are mandatory

--- a/skills/.experimental/fusion-design/SKILL.md
+++ b/skills/.experimental/fusion-design/SKILL.md
@@ -20,11 +20,13 @@ Any time you are writing or reviewing frontend code in the Fusion ecosystem and 
 
 ## Instructions
 
-This skill is a lookup. Read the relevant reference file, then apply the rules.
+This skill is a lookup. Read **all** reference files before writing any code — they define mandatory requirements, not optional styling.
 
 ### 1. Read the references
 
-> **Note:** Reference files are not yet published. This section will be populated once `references/` is committed.
+| Topic | File |
+|---|---|
+| EDS Typography | `references/eds-typography.md` |
 
 ### 2. Check for a local `DESIGN.md`
 

--- a/skills/.experimental/fusion-design/references/eds-typography.md
+++ b/skills/.experimental/fusion-design/references/eds-typography.md
@@ -1,11 +1,11 @@
 # EDS Typography
 
-Source: `docs/guidelines/eds-typography.md`
+Source: https://eds.equinor.com/
 
 ## Rules
 
 - **Always** use `<Typography>` from `@equinor/eds-core-react` for all text — headings, body, captions.
-- **Never** use bare HTML elements (`<h1>`–`<h6>`, `<p>`, `<span>` without styling).
+- **Never** use bare HTML elements (`<h1>`–`<h6>`, `<p>`, `<span>`) — always use `<Typography>` regardless of styling.
 - **Never** hardcode font sizes, weights, or line heights in CSS or `style` props.
 
 ## Import

--- a/skills/.experimental/fusion-design/references/eds-typography.md
+++ b/skills/.experimental/fusion-design/references/eds-typography.md
@@ -1,0 +1,37 @@
+# EDS Typography
+
+Source: `docs/guidelines/eds-typography.md`
+
+## Rules
+
+- **Always** use `<Typography>` from `@equinor/eds-core-react` for all text — headings, body, captions.
+- **Never** use bare HTML elements (`<h1>`–`<h6>`, `<p>`, `<span>` without styling).
+- **Never** hardcode font sizes, weights, or line heights in CSS or `style` props.
+
+## Import
+
+```tsx
+import { Typography } from '@equinor/eds-core-react';
+```
+
+## Heading variants
+
+| Semantic level | Prop |
+|---|---|
+| Page title | `variant="h1"` |
+| Section title | `variant="h2"` |
+| Sub-section | `variant="h3"` |
+| Card/panel title | `variant="h4"` |
+
+## Example
+
+```tsx
+// ✅ Correct
+<Typography variant="h1">My Page</Typography>
+
+// ❌ Wrong — plain HTML
+<h1>My Page</h1>
+
+// ❌ Wrong — hardcoded styles
+<h1 style={{ fontSize: '32px' }}>My Page</h1>
+```


### PR DESCRIPTION
## Why

The `fusion-design` skill referenced a `references/` directory that didn't exist yet. Agents activating the skill had no actual rules to look up, making it ineffective.

## Current behavior

SKILL.md contained a placeholder note saying reference files were not yet published. No typography rules were available to agents.

## New behavior

- `references/eds-typography.md` is committed with EDS typography rules.
- SKILL.md updated to list the reference table and clarify all references are mandatory, not optional styling guides.

## References

- Issue(s): —
- Related PR(s): —
- Docs / specs: https://eds.equinor.com/

## Reviewer focus

- Start here: `skills/.experimental/fusion-design/references/eds-typography.md`, `skills/.experimental/fusion-design/SKILL.md`
- Verify these behavior changes: agents activating `fusion-design` will now find and read `eds-typography.md`
- Risky or security-sensitive parts: none

## Self review checklist

- [x] I scoped this PR to one clear purpose.
- [x] I followed [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I did not include secrets, credentials, or sensitive data.
- [x] I reviewed my own diff for clarity and unintended changes.
