### PR TITLE
feat(skill): add sidemenu navigation reference to fusion-design

### DIFF
--- a/.changeset/fusion-design-sidemenu-reference-b3c72a1f.md
+++ b/.changeset/fusion-design-sidemenu-reference-b3c72a1f.md
@@ -1,0 +1,8 @@
+---
+"fusion-design": patch
+---
+
+Add sidemenu navigation reference
+
+- Add `references/navigation-sidemenu.md` with sidemenu structure, hierarchy, and breadcrumb rules
+- Update SKILL.md reference table to include the new navigation reference

--- a/skills/.experimental/fusion-design/SKILL.md
+++ b/skills/.experimental/fusion-design/SKILL.md
@@ -27,6 +27,7 @@ This skill is a lookup. Read **all** reference files before writing any code —
 | Topic | File |
 |---|---|
 | EDS Typography | `references/eds-typography.md` |
+| Navigation — Sidemenu | `references/navigation-sidemenu.md` |
 
 ### 2. Check for a local `DESIGN.md`
 

--- a/skills/.experimental/fusion-design/references/navigation-sidemenu.md
+++ b/skills/.experimental/fusion-design/references/navigation-sidemenu.md
@@ -1,0 +1,48 @@
+# Navigation — Sidemenu
+
+Source: `docs/guidelines/navigation/navigation-sidemenu.md`
+
+## Rules
+
+- **Use a sidemenu when the app has 3 or more distinct sections** — for fewer than 3 sections, use tabs instead.
+- **Never combine sidemenu and tabs at the same hierarchy level** — the sidemenu handles all top-level navigation on its own.
+- **Maximum navigation depth is 4 levels** — if the app requires more, reconsider the information architecture.
+- **Expand the sidemenu by default on first arrival** — never hide or collapse it on load.
+- **Never put state-driven actions in the sidemenu** (Save, Delete, Confirm) — place actions in the content area.
+- **Never create single-child groups** — if a parent has only one child, flatten it to a top-level item.
+
+## Structure levels
+
+| Level | Description |
+|---|---|
+| A | App root / landing page — first breadcrumb segment |
+| B | Top-level sections — primary sidemenu items |
+| C | Child items — indented under their parent B when expanded |
+| D | Deepest recommended level — do not go beyond this |
+
+## Breadcrumbs
+
+- Show breadcrumbs when the app has 2 or more levels of navigation depth.
+- **Never** show breadcrumbs on the top-level entry point — there is nowhere to navigate back to.
+- The current page is the last breadcrumb segment and is **not** a clickable link.
+- Each breadcrumb item links to the index/overview of that level.
+- Use the actual entity name for dynamic segments — not a generic label.
+- **Never** style breadcrumbs as tabs — they are different patterns with different meanings.
+- **Never** truncate breadcrumb items unless screen space is critically limited.
+
+## Example structure
+
+```
+App (A)
+├── Overview (B)
+├── Applications (B)
+│   ├── App list (C)
+│   └── App details (C)
+├── Settings (B)
+│   ├── Users (C)
+│   ├── Roles (C)
+│   └── Integrations (C)
+└── Help (B)
+```
+
+Breadcrumb when on Settings › Roles: **App** › **Settings** › Roles

--- a/skills/.experimental/fusion-design/references/navigation-sidemenu.md
+++ b/skills/.experimental/fusion-design/references/navigation-sidemenu.md
@@ -1,7 +1,5 @@
 # Navigation — Sidemenu
 
-Source: `docs/guidelines/navigation/navigation-sidemenu.md`
-
 ## Rules
 
 - **Use a sidemenu when the app has 3 or more distinct sections** — for fewer than 3 sections, use tabs instead.


### PR DESCRIPTION
## Why

Add a sidemenu navigation reference to the `fusion-design` skill so agents can look up sidemenu structure, hierarchy, and breadcrumb rules when implementing Fusion UI navigation.

## Current behavior

The `fusion-design` skill has no guidance on when or how to use a sidemenu. Agents lack a canonical source for:

- when to choose sidemenu vs tabs
- parent/child navigation depth rules
- breadcrumb placement rules
- what actions are never allowed in the sidemenu

## New behavior

Adds "Navigation — Sidemenu" to the skill's reference table and introduces `references/navigation-sidemenu.md` with the following guidance:

- When to use a sidemenu (3+ distinct sections)
- Hierarchy levels (A–D) and what each represents
- Breadcrumb rules (when to show, never on entry point, not clickable for current page)
- What to never put in the sidemenu (state-driven actions, single-child groups)

## References

Issue(s): N/A
Related PR(s): N/A
Docs / specs: `skills/.experimental/fusion-design/references/navigation-sidemenu.md`

## Reviewer focus

- Start here: `skills/.experimental/fusion-design/references/navigation-sidemenu.md`
- Verify: rules are complete, unambiguous, and consistent with the EDS/Fusion design system
- Risky or security-sensitive parts: none — skill reference content only

## Self review checklist

- [x] I scoped this PR to one clear purpose.
- [x] I followed [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I did not include secrets, credentials, or sensitive data.
- [x] I reviewed my own diff for clarity and unintended changes.
