### PR TITLE
fix(fusion-devtools): add SECURITY.md explaining High Risk false positive

### DIFF
--- a/.changeset/fusion-devtools-security-doc.md
+++ b/.changeset/fusion-devtools-security-doc.md
@@ -1,0 +1,11 @@
+---
+"fusion-devtools": patch
+---
+
+Add SECURITY.md explaining High Risk false positive
+
+Static analysis flags the token-in-shell-variable patterns in
+`references/agentic-patterns.md` (Pattern 2 and Pattern 7) as a credential
+exposure risk. The file documents that these are false positives — the skill
+contains no scripts or executable code, and the tokens are short-lived Azure AD
+bearer tokens that exist only as local shell variables during a command.

--- a/skills/fusion-devtools/SECURITY.md
+++ b/skills/fusion-devtools/SECURITY.md
@@ -25,7 +25,7 @@ Static analyzers flag `TOKEN=$(...)` combined with `Authorization: Bearer $TOKEN
 
 ### What the skill does NOT do
 
-- Does not store, log, or transmit tokens outside the local shell session
+- Does not store or log tokens outside the local shell session
 - Does not hardcode credentials or secrets anywhere in the skill files
 - Does not execute code — it is documentation only (no scripts)
 - Does not make network requests itself; it describes CLI usage patterns
@@ -37,4 +37,4 @@ The token is a short-lived Azure AD bearer token obtained interactively via `fde
 
 ### Reporting a vulnerability
 
-If you believe you've found a genuine security issue, open a GitHub issue in [equinor/fusion-skills](https://github.com/equinor/fusion-skills) with the label `security`.
+Do not create a public GitHub issue. Follow the Equinor Responsible Disclosure Policy at https://www.equinor.com/about-us/csirt.

--- a/skills/fusion-devtools/SECURITY.md
+++ b/skills/fusion-devtools/SECURITY.md
@@ -1,0 +1,40 @@
+# Security
+
+## High Risk Rating — False Positive
+
+`fusion-devtools` receives a High Risk rating from static analysis (e.g. Snyk) due to token-handling patterns in the reference documentation. This document explains what the skill does and does not do.
+
+### What triggers the rating
+
+Two code examples in `references/agentic-patterns.md` match credential-in-shell-variable heuristics:
+
+**Pattern 2 — Get a token for external tools:**
+```bash
+TOKEN=$(fdev get-access-token --service-key people | jq -r '.accessToken')
+curl -H "Authorization: Bearer $TOKEN" "$BASE_URL/persons/me?api-version=3.0"
+```
+
+**Pattern 7 — Chain discovery with token for scripting:**
+```bash
+TOKEN=$(fdev get-access-token --service-key org | jq -r '.accessToken')
+curl -s -H "Authorization: Bearer $TOKEN" "$BASE_URL/projects?api-version=3.0" | jq '.value | length'
+```
+
+Static analyzers flag `TOKEN=$(...)` combined with `Authorization: Bearer $TOKEN` as potential credential exposure. The skill documentation already cautions:
+> "Prefer `fdev rest` with `--url` when possible — it handles tokens internally without exposing them. Use the variable approach only when another tool must make the HTTP call."
+
+### What the skill does NOT do
+
+- Does not store, log, or transmit tokens outside the local shell session
+- Does not hardcode credentials or secrets anywhere in the skill files
+- Does not execute code — it is documentation only (no scripts)
+- Does not make network requests itself; it describes CLI usage patterns
+
+### Why the token pattern is safe
+
+The token is a short-lived Azure AD bearer token obtained interactively via `fdev login` (browser-based Azure AD flow) or service principal login. It exists only as a local shell variable for the duration of the command and is never written to disk. The skill also includes a safety reminder:
+> "Redact tokens: when showing output to users, truncate or mask `accessToken` values."
+
+### Reporting a vulnerability
+
+If you believe you've found a genuine security issue, open a GitHub issue in [equinor/fusion-skills](https://github.com/equinor/fusion-skills) with the label `security`.


### PR DESCRIPTION
## Why

The `fusion-devtools` skill receives a **High Risk / 1 alert** rating from skill installers due to static analysis heuristics. Users installing the skill see a warning that implies a real security risk, when it is actually a false positive.

## Current behavior

No `SECURITY.md` exists for `fusion-devtools`. The high-risk rating surfaces to users installing the skill with no explanation.

`caveman-compress` has the same issue and already has a `SECURITY.md` documenting its false positive — this PR applies the same pattern to `fusion-devtools`.

## New behavior

A `SECURITY.md` at `skills/fusion-devtools/SECURITY.md` explains:
- Which patterns trigger the rating (Pattern 2 and Pattern 7 in `references/agentic-patterns.md`: `TOKEN=$(fdev get-access-token ...)` + `curl -H "Authorization: Bearer $TOKEN"`)
- Why these are false positives (skill is documentation-only, no scripts, tokens are short-lived local shell variables from an interactive Azure AD login)
- How to report a genuine vulnerability

## References

- Issue(s): n/a
- Related PR(s): n/a
- Docs / specs: [`caveman-compress/SECURITY.md`](../../.agents/skills/caveman-compress/SECURITY.md) (precedent pattern)

## Reviewer focus

- Start here: `skills/fusion-devtools/SECURITY.md`
- Verify the explanation accurately reflects what Pattern 2 and Pattern 7 in `references/agentic-patterns.md` do
- Risky or security-sensitive parts: none — this is documentation only

## Self review checklist

- [x] I scoped this PR to one clear purpose.
- [x] I followed [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I did not include secrets, credentials, or sensitive data.
- [x] I reviewed my own diff for clarity and unintended changes.

## Validation evidence

```
npx -y skills add . --list   ✓ (32 skills listed, fusion-devtools present)
bun run validate:skills      ✓ Skill count check passed (32/32)
bun run validate:ownership   ✓ Ownership validation: 32/32 skills passed
bun run biome:check          ✓ No fixes applied (1 info — pre-existing migrate notice)
```
