### PR TITLE
feat: add fusion-infra-cli and fusion-roles-cli skills

### DIFF
--- a/.changeset/fusion-infra-cli-new-skill.md
+++ b/.changeset/fusion-infra-cli-new-skill.md
@@ -1,0 +1,13 @@
+---
+"fusion-infra-cli": patch
+---
+
+Add fusion-infra-cli skill for database provisioning
+
+New skill covering the `finf` CLI tool for provisioning and migrating Fusion
+databases. Primary use case is deploying databases via CI/CD pipelines.
+
+Includes:
+- SKILL.md with core workflows for provision, migrate, PR databases
+- references/command-reference.md with all flags for all subcommands
+- references/db-config-schema.md with the full provisioning config JSON schema

--- a/.changeset/fusion-infra-cli-new-skill.md
+++ b/.changeset/fusion-infra-cli-new-skill.md
@@ -9,5 +9,4 @@ databases. Primary use case is deploying databases via CI/CD pipelines.
 
 Includes:
 - SKILL.md with core workflows for provision, migrate, PR databases
-- references/command-reference.md with all flags for all subcommands
 - references/db-config-schema.md with the full provisioning config JSON schema

--- a/.changeset/fusion-roles-cli-new-skill.md
+++ b/.changeset/fusion-roles-cli-new-skill.md
@@ -9,7 +9,6 @@ configuration from JSON config files.
 
 Includes:
 - SKILL.md with core workflows for create, dry-run, export
-- references/command-reference.md with all commands and flags
 - references/role-config-schema.md with the full JSON schema for all resource
   types (scope types, access roles, roles, claimable roles, bindings,
   role assignments, claimable role assignments)

--- a/.changeset/fusion-roles-cli-new-skill.md
+++ b/.changeset/fusion-roles-cli-new-skill.md
@@ -1,0 +1,15 @@
+---
+"fusion-roles-cli": patch
+---
+
+Add fusion-roles-cli skill for role config deployment
+
+New skill covering the `froles` CLI tool for deploying Fusion Roles V2
+configuration from JSON config files.
+
+Includes:
+- SKILL.md with core workflows for create, dry-run, export
+- references/command-reference.md with all commands and flags
+- references/role-config-schema.md with the full JSON schema for all resource
+  types (scope types, access roles, roles, claimable roles, bindings,
+  role assignments, claimable role assignments)

--- a/skills/fusion-infra-cli/SKILL.md
+++ b/skills/fusion-infra-cli/SKILL.md
@@ -58,7 +58,7 @@ dotnet tool update --global \
   Fusion.Infra.Cli
 ```
 
-Auth uses `DefaultAzureCredentials` automatically (picks up `az login` session). Pass `-t <token>` to override.
+Auth uses `DefaultAzureCredential` automatically (picks up `az login` session). Pass `-t <token>` to override.
 
 ## Core workflow — provision a database
 

--- a/skills/fusion-infra-cli/SKILL.md
+++ b/skills/fusion-infra-cli/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: fusion-infra-cli
+description: 'Provision and migrate Fusion databases using the fusion-infra-cli (finf). USE FOR: provision a database for a service, run SQL migrations, provision PR-specific ephemeral databases, check database state. DO NOT USE FOR: application code changes, service deployments, role management, or infrastructure other than databases.'
+license: MIT
+compatibility: >
+  Requires finf installed as a .NET global tool from the Fusion-Public NuGet feed.
+  Requires Azure CLI login (az login) or explicit token via -t flag.
+metadata:
+  version: "0.0.0"
+  status: active
+  owner: "@equinor/fusion-core"
+  tags:
+    - fusion
+    - infra
+    - database
+    - cli
+    - provisioning
+    - migrations
+    - devops
+---
+
+# Fusion Infra CLI
+
+## When to use
+
+Use when a Fusion service database needs to be provisioned or migrated — locally during development or inside CI/CD pipelines.
+
+Typical triggers:
+- "Provision the database for the context service"
+- "Run migrations on the QA database"
+- "Set up a PR database for this pull request"
+- "What does the database provision config look like?"
+- "The pipeline is failing on the database provision step"
+- "Create a PR database that copies from CI"
+
+## When not to use
+
+- Application code or service changes — use the service repo
+- Role or permission management — use `fusion-roles-cli`
+- Infrastructure other than databases (networking, storage, etc.)
+- Kubernetes or container management
+
+## Prerequisites
+
+Install `finf` as a .NET global tool:
+
+```bash
+dotnet tool install --global \
+  --add-source "https://statoil-proview.pkgs.visualstudio.com/Fusion%20-%20Packages/_packaging/Fusion-Public/nuget/v3/index.json" \
+  Fusion.Infra.Cli
+```
+
+Update to latest:
+
+```bash
+dotnet tool update --global \
+  --add-source "https://statoil-proview.pkgs.visualstudio.com/Fusion%20-%20Packages/_packaging/Fusion-Public/nuget/v3/index.json" \
+  Fusion.Infra.Cli
+```
+
+Auth uses `DefaultAzureCredentials` automatically (picks up `az login` session). Pass `-t <token>` to override.
+
+## Core workflow — provision a database
+
+### 1. Create the provisioning config file
+
+The config file defines the database resource. Minimal example (`db-config.json`):
+
+```json
+{
+  "name": "my-service",
+  "environment": "ci"
+}
+```
+
+Full config with SQL permissions:
+
+```json
+{
+  "name": "my-service",
+  "environment": "fqa",
+  "sqlPermission": {
+    "owners": [
+      { "clientId": "<app-registration-client-id>" }
+    ],
+    "contributors": [
+      { "clientId": "<app-registration-client-id>" }
+    ]
+  }
+}
+```
+
+See [references/db-config-schema.md](references/db-config-schema.md) for the full schema.
+
+### 2. Run provisioning
+
+**CI / non-production:**
+```bash
+finf database provision -f db-config.json -e ci \
+  --sql-owner-client-id <client-id> \
+  --sql-contributor-client-id <client-id> \
+  -o response.json --verbose
+```
+
+**QA:**
+```bash
+finf database provision -f db-config.json -e fqa \
+  --sql-owner-client-id <client-id> \
+  --sql-contributor-client-id <client-id> \
+  -o response.json --verbose
+```
+
+**Production** (add `--production` flag):
+```bash
+finf database provision -f db-config.json -e fprd \
+  --production \
+  --sql-owner-client-id <client-id> \
+  --sql-contributor-client-id <client-id> \
+  -o response.json --verbose
+```
+
+**Pull Request** (ephemeral database, copies from CI):
+```bash
+finf database provision -f db-config.json \
+  -e pr -pr <pr-number> -ghr "equinor/my-repo" -c ci \
+  --sql-owner-client-id <client-id> \
+  --sql-contributor-client-id <client-id> \
+  --timeout 500 -o response.json --verbose
+```
+
+### 3. Run migrations
+
+After provisioning, apply SQL migrations:
+
+```bash
+# Non-production
+finf database migrate -d sql-myservice-fqa -m migrations/ \
+  -o migrations.json --verbose
+
+# Production
+finf database migrate -d sql-myservice-fprd -m migrations/ \
+  --production -o migrations.json --verbose
+```
+
+The `-m` flag accepts a directory of `.sql` files or a single `.sql` file.
+
+## Environments
+
+| Key | Purpose |
+|-----|---------|
+| `ci` | Continuous integration |
+| `fqa` | QA / pre-production |
+| `fprd` | Production (requires `--production` flag) |
+| `pr` | Pull request ephemeral (requires `-pr` and `-ghr`) |
+
+## Full reference
+
+For complete flag reference, run:
+```bash
+finf database provision --help
+finf database migrate --help
+```
+
+Or see the source documentation:
+- [README.md](https://github.com/equinor/fusion-core-services/blob/main/tooling/fusion-infra-cli/Fusion.Infra.Cli/README.md)
+- [Source: tooling/fusion-infra-cli](https://github.com/equinor/fusion-core-services/tree/main/tooling/fusion-infra-cli)
+
+## Safety
+
+- Always use `--verbose` in pipelines to get diagnostic output
+- Always save output with `-o response.json` so pipeline steps can reference the result
+- The `--production` flag is an explicit guard — never omit it for `fprd` provisioning
+- Never pass raw tokens in pipeline YAML — use secret variables and pass via `-t`
+- `database delete` is irreversible for non-PR databases — confirm with user before running

--- a/skills/fusion-infra-cli/references/db-config-schema.md
+++ b/skills/fusion-infra-cli/references/db-config-schema.md
@@ -1,0 +1,148 @@
+# Database Provisioning Config Schema
+
+Config file for `finf database provision -f <file>`. All fields are optional unless noted.
+
+> **Source of truth**: [`ProvisionDatabaseCommand.cs`](https://github.com/equinor/fusion-core-services/blob/main/tooling/fusion-infra-cli/Fusion.Infra.Cli/Commands/Database/ProvisionDatabaseCommand.cs) and the [infra-cli README](https://github.com/equinor/fusion-core-services/blob/main/tooling/fusion-infra-cli/Fusion.Infra.Cli/README.md). If this file conflicts with the source, the source wins.
+
+## Root object
+
+```json
+{
+  "name": "string",
+  "environment": "ci | fqa | fprd | pr",
+  "pullRequest": { ... },
+  "sqlPermission": { ... },
+  "accessControl": { ... },
+  "configuration": { ... },
+  "metadata": { "key": "string" },
+  "annotations": { "key": "string" }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | App name; used to derive DB name. Can be overridden with `-an`. |
+| `environment` | string | Target environment. Can be overridden with `-e`. |
+| `pullRequest` | object | PR-specific config. Can be supplied via CLI flags instead. |
+| `sqlPermission` | object | SQL owner/contributor definitions. Can be supplied via CLI flags instead. |
+| `accessControl` | object | Access control group names. Can be supplied via CLI flags instead. |
+| `configuration` | object | Advanced database name/provisioning mode config. |
+| `metadata` | object | Custom key-value metadata. |
+| `annotations` | object | Custom key-value annotations (merged with auto-detected pipeline annotations). |
+
+---
+
+## `pullRequest` object
+
+```json
+{
+  "pullRequest": {
+    "pullRequestNumber": "123",
+    "gitHubRepository": "equinor/my-repo",
+    "copyFromEnvironment": "ci"
+  }
+}
+```
+
+All three fields can alternatively be passed as CLI flags: `-pr`, `-ghr`, `-c`.
+
+---
+
+## `sqlPermission` object
+
+```json
+{
+  "sqlPermission": {
+    "owners": [
+      {
+        "objectId": "guid (optional)",
+        "clientId": "guid (optional)",
+        "displayName": "string (optional)"
+      }
+    ],
+    "contributors": [
+      {
+        "objectId": "guid (optional)",
+        "clientId": "guid (optional)",
+        "displayName": "string (optional)"
+      }
+    ]
+  }
+}
+```
+
+- **owners**: Full SQL control (db_owner)
+- **contributors**: Read/write access (db_datareader + db_datawriter)
+- Provide either `objectId` (Azure AD object ID) or `clientId` (app registration client ID)
+- Can also be set via `--sql-owner-client-id`, `--sql-contributor-client-id`, etc. CLI flags
+
+---
+
+## `accessControl` object
+
+```json
+{
+  "accessControl": {
+    "administratorGroupName": "string",
+    "developerGroupName": "string"
+  }
+}
+```
+
+Members of the admin group are auto-approved for owner access; developer group for contributor access.
+
+---
+
+## `configuration` object
+
+```json
+{
+  "configuration": {
+    "databaseFullyQualifiedName": "sql-myservice-[environment]",
+    "provisioningMode": "string"
+  }
+}
+```
+
+The `[environment]` placeholder in `databaseFullyQualifiedName` is substituted with the resolved environment name.
+
+---
+
+## Minimal working example
+
+```json
+{
+  "name": "my-service",
+  "environment": "ci"
+}
+```
+
+Permission principals are then supplied via CLI flags:
+```bash
+finf database provision -f db-config.json \
+  --sql-owner-client-id <app-client-id> \
+  --sql-contributor-client-id <app-client-id> \
+  -o response.json --verbose
+```
+
+---
+
+## Full example with permissions in file
+
+```json
+{
+  "name": "context",
+  "environment": "fqa",
+  "sqlPermission": {
+    "owners": [
+      { "clientId": "5a842df8-3238-415d-b168-9f16a6a6031b" }
+    ],
+    "contributors": [
+      { "clientId": "5a842df8-3238-415d-b168-9f16a6a6031b" }
+    ]
+  },
+  "accessControl": {
+    "developerGroupName": "Fusion Core Developers"
+  }
+}
+```

--- a/skills/fusion-infra-cli/references/db-config-schema.md
+++ b/skills/fusion-infra-cli/references/db-config-schema.md
@@ -135,10 +135,10 @@ finf database provision -f db-config.json \
   "environment": "fqa",
   "sqlPermission": {
     "owners": [
-      { "clientId": "5a842df8-3238-415d-b168-9f16a6a6031b" }
+      { "clientId": "<app-registration-client-id>" }
     ],
     "contributors": [
-      { "clientId": "5a842df8-3238-415d-b168-9f16a6a6031b" }
+      { "clientId": "<app-registration-client-id>" }
     ]
   },
   "accessControl": {

--- a/skills/fusion-roles-cli/SKILL.md
+++ b/skills/fusion-roles-cli/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: fusion-roles-cli
+description: 'Deploy and manage Fusion Roles V2 configuration using the fusion-roles-cli (froles). USE FOR: deploy role config from a JSON file, create roles/bindings/assignments, export current role state, inspect role assignments. DO NOT USE FOR: database provisioning, application code changes, Azure AD group management outside role bindings, or Roles V1 management.'
+license: MIT
+compatibility: >
+  Requires froles installed as a .NET global tool from the Fusion-Public NuGet feed.
+  Requires Azure CLI login (az login) or explicit token via -t flag.
+metadata:
+  version: "0.0.0"
+  status: active
+  owner: "@equinor/fusion-core"
+  tags:
+    - fusion
+    - roles
+    - cli
+    - rbac
+    - role-config
+    - devops
+---
+
+# Fusion Roles CLI
+
+## When to use
+
+Use when Fusion Roles V2 resources (roles, bindings, assignments, scope types) need to be created or updated from a config file, or when existing role state needs to be inspected or exported.
+
+Typical triggers:
+- "Deploy the roles config for my service"
+- "Create roles from this JSON file"
+- "Export the current role config for fusion-myservice"
+- "What does a roles config file look like?"
+- "Add a binding for this Entra group"
+- "Check what roles are assigned to this account"
+- "Dry-run the role deployment"
+
+## When not to use
+
+- Database provisioning — use `fusion-infra-cli`
+- Managing Azure AD groups themselves — use the Azure portal or Graph API
+- Roles V1 (legacy system) — this tool targets Roles V2 only
+- Application code changes
+
+## Prerequisites
+
+Install `froles` as a .NET global tool:
+
+```bash
+dotnet tool install --global \
+  --add-source "https://statoil-proview.pkgs.visualstudio.com/Fusion%20-%20Packages/_packaging/Fusion-Public/nuget/v3/index.json" \
+  Fusion.Roles.Cli
+```
+
+Update to latest:
+
+```bash
+froles --update
+```
+
+Auth uses `DefaultAzureCredentials` automatically (picks up `az login` session). Pass `-t <token>` to override.
+
+## Core workflow — deploy a role config
+
+### 1. Create the config file
+
+The config file is a JSON file declaring all role resources for your system. Always include the `$schema` reference — it enables editor validation and autocompletion.
+
+Minimal example (`roles-config.json`):
+
+```json
+{
+  "$schema": "https://rolesv2.api.fusion.equinor.com/public/schemas/role-config.schema.json",
+  "accessRoles": [
+    {
+      "systemIdentifier": "my-service",
+      "name": "MyService.Project.Read",
+      "description": "Read access to project resources"
+    }
+  ],
+  "roles": [
+    {
+      "name": "project-viewer",
+      "displayName": "Project Viewer",
+      "accessRoleMappings": [
+        { "accessRoleIdentifier": "MyService.Project.Read" }
+      ]
+    }
+  ]
+}
+```
+
+See [references/role-config-schema.md](references/role-config-schema.md) for the full schema with all resource types and field definitions.
+
+### 2. Dry-run to verify changes
+
+Always dry-run before deploying to catch unexpected changes:
+
+```bash
+froles create -e ci --file roles-config.json --dry-run
+```
+
+The dry-run shows exactly what will be created, patched, or left unchanged — including binding diffs showing added/removed roles.
+
+### 3. Deploy
+
+```bash
+# CI
+froles create -e ci --file roles-config.json
+
+# QA
+froles create -e fqa --file roles-config.json
+
+# Production
+froles create -e fprd --file roles-config.json
+```
+
+`create` is **idempotent** — safe to run repeatedly. Resources are matched on natural keys; only changed fields are patched.
+
+### 4. Export current state (optional)
+
+To export the current configuration for a system (useful for initial onboarding or auditing):
+
+```bash
+froles export my-service -e ci -o current-state.json
+```
+
+The export file can be modified and fed back into `create`.
+
+## Reconciliation behaviour
+
+The `create` command reconciles each resource type against its natural key:
+
+| Resource | Natural key | Behaviour |
+|----------|------------|-----------|
+| Scope types | `name` | Create if missing; patch `description` if changed |
+| Access roles | `systemIdentifier` + `name` | Create if missing; patch if changed |
+| Roles / claimable roles | `name` | Create if missing; patch if changed; access role mappings fully reconciled |
+| Bindings | `identifier` | Patch all fields; diff shows role/group additions and removals |
+| Role assignments | `roleName` + `source` + `externalIdentifier` | Create if missing; skip if exists |
+
+**Important**: Access role mappings on roles/claimable roles are **fully reconciled** — mappings absent from the config are removed. Only access roles belonging to systems declared in the config file are managed.
+
+## Environments
+
+| Key | Purpose |
+|-----|---------|
+| `ci` | Continuous integration |
+| `fqa` | QA / pre-production |
+| `fprd` | Production |
+| `tr` | Training environment |
+
+## Full reference
+
+For complete command and flag reference, run:
+```bash
+froles --help
+froles create --help
+```
+
+Or see the source documentation:
+- [README.md](https://github.com/equinor/fusion-core-services/blob/main/tooling/fusion-roles-cli/Fusion.Roles.Cli/README.md)
+- [USING_CREATE_COMMAND.md](https://github.com/equinor/fusion-core-services/blob/main/tooling/fusion-roles-cli/Fusion.Roles.Cli/USING_CREATE_COMMAND.md)
+- [Source: tooling/fusion-roles-cli](https://github.com/equinor/fusion-core-services/tree/main/tooling/fusion-roles-cli)
+
+## Safety
+
+- Always dry-run before deploying to production
+- Access role mapping reconciliation removes unmapped roles — review the dry-run output carefully
+- Never store tokens in config files; always use `-t <token>` from a secret variable in pipelines
+- `delete role-assignments` is destructive — confirm with user and dry-run first

--- a/skills/fusion-roles-cli/SKILL.md
+++ b/skills/fusion-roles-cli/SKILL.md
@@ -56,7 +56,7 @@ Update to latest:
 froles --update
 ```
 
-Auth uses `DefaultAzureCredentials` automatically (picks up `az login` session). Pass `-t <token>` to override.
+Auth uses `DefaultAzureCredential` automatically (picks up `az login` session). Pass `-t <token>` to override.
 
 ## Core workflow — deploy a role config
 
@@ -135,7 +135,7 @@ The `create` command reconciles each resource type against its natural key:
 | Access roles | `systemIdentifier` + `name` | Create if missing; patch if changed |
 | Roles / claimable roles | `name` | Create if missing; patch if changed; access role mappings fully reconciled |
 | Bindings | `identifier` | Patch all fields; diff shows role/group additions and removals |
-| Role assignments | `roleName` + `source` + `externalIdentifier` | Create if missing; skip if exists |
+| Role assignments | `roleIdentifier` + `source` + `externalIdentifier` | Create if missing; skip if exists |
 
 **Important**: Access role mappings on roles/claimable roles are **fully reconciled** — mappings absent from the config are removed. Only access roles belonging to systems declared in the config file are managed.
 

--- a/skills/fusion-roles-cli/references/role-config-schema.md
+++ b/skills/fusion-roles-cli/references/role-config-schema.md
@@ -241,7 +241,7 @@ A direct role assignment for a specific identity.
 }
 ```
 
-**Unique key**: `roleName` + `source` + `externalIdentifier`
+**Unique key**: `roleIdentifier` + `source` + `externalIdentifier`
 **Behaviour**: Create if missing; skip if exists. No partial updates.
 
 **Example:**

--- a/skills/fusion-roles-cli/references/role-config-schema.md
+++ b/skills/fusion-roles-cli/references/role-config-schema.md
@@ -1,0 +1,353 @@
+# Role Config Schema
+
+Config file for `froles create --file <path>`. All sections are optional — include only what you need to manage.
+
+> **Canonical schema**: [`https://rolesv2.api.fusion.equinor.com/public/schemas/role-config.schema.json`](https://rolesv2.api.fusion.equinor.com/public/schemas/role-config.schema.json) — this is the live, authoritative schema. See also [USING_CREATE_COMMAND.md](https://github.com/equinor/fusion-core-services/blob/main/tooling/fusion-roles-cli/Fusion.Roles.Cli/USING_CREATE_COMMAND.md) and [sample-create-file.json](https://github.com/equinor/fusion-core-services/blob/main/tooling/fusion-roles-cli/Fusion.Roles.Cli/sample-create-file.json).
+
+**Always add the `$schema` reference** for editor validation and autocompletion:
+
+```json
+{
+  "$schema": "https://rolesv2.api.fusion.equinor.com/public/schemas/role-config.schema.json"
+}
+```
+
+---
+
+## Root object
+
+```json
+{
+  "$schema": "string (recommended)",
+  "scopeTypes": [ ScopeType ],
+  "accessRoles": [ AccessRole ],
+  "roles": [ Role ],
+  "claimableRoles": [ ClaimableRole ],
+  "bindings": [ Binding ],
+  "roleAssignments": [ RoleAssignment ],
+  "claimableRoleAssignments": [ ClaimableRoleAssignment ],
+  "deleteRoleAssignments": [ DeleteRoleAssignmentRequest ]
+}
+```
+
+All arrays are optional. Omit sections you don't manage.
+
+---
+
+## ScopeType
+
+Defines a scope dimension used to constrain roles (e.g. `project`, `contract`).
+
+```json
+{
+  "name": "string (required — unique key)",
+  "description": "string (optional)"
+}
+```
+
+**Example:**
+```json
+{ "name": "project", "description": "Project scope" }
+```
+
+---
+
+## AccessRole
+
+An API permission owned by a system. Access roles are the leaf permissions that roles aggregate.
+
+```json
+{
+  "systemIdentifier": "string (required — owning system identifier)",
+  "name": "string (required — unique within system)",
+  "description": "string (optional)",
+  "scopeTypeIdentifier": "string (optional — links to a scope type)"
+}
+```
+
+**Unique key**: `systemIdentifier` + `name`
+
+**Example:**
+```json
+{
+  "systemIdentifier": "my-service",
+  "name": "MyService.Project.Write",
+  "description": "Write access to project resources",
+  "scopeTypeIdentifier": "project"
+}
+```
+
+---
+
+## Role
+
+A named role that groups access roles. Users are assigned roles, not access roles directly.
+
+```json
+{
+  "name": "string (required — unique key)",
+  "displayName": "string (optional)",
+  "description": "string (optional)",
+  "accessRoleMappings": [
+    {
+      "accessRoleIdentifier": "string (access role name — required)",
+      "reason": "string (optional — explains why this mapping exists)"
+    }
+  ]
+}
+```
+
+**Warning**: `accessRoleMappings` is **fully reconciled** — mappings absent from the config are removed. Only access roles from systems declared in the config file are managed.
+
+**Example:**
+```json
+{
+  "name": "project-editor",
+  "displayName": "Project Editor",
+  "description": "Can edit project resources",
+  "accessRoleMappings": [
+    {
+      "accessRoleIdentifier": "MyService.Project.Write",
+      "reason": "Editors need write access"
+    }
+  ]
+}
+```
+
+---
+
+## ClaimableRole
+
+Same structure as `Role`. Users can self-service claim these roles.
+
+```json
+{
+  "name": "string (required — unique key)",
+  "displayName": "string (optional)",
+  "description": "string (optional)",
+  "accessRoleMappings": [ ... ]
+}
+```
+
+---
+
+## Binding
+
+Links an Entra (Azure AD) group to roles or claimable roles, optionally scoped.
+
+```json
+{
+  "identifier": "string (required — unique key)",
+  "system": "string (required — owning system identifier)",
+  "description": "string (optional)",
+  "reason": "string (optional — explains binding purpose)",
+  "type": "string (e.g. 'EntraGroup')",
+  "sourceSystem": "string (e.g. 'Entra')",
+  "version": "string (optional)",
+  "binding": {
+    "version": "string (optional)",
+    "group": {
+      "id": "GUID (Entra group object ID)",
+      "name": "string (optional — display name only)"
+    },
+    "roles": [
+      {
+        "name": "string (role name)",
+        "type": "string (optional)",
+        "scope": {
+          "scopeTypeIdentifier": "string",
+          "isGlobal": "boolean (true for global scope)",
+          "value": "string (scope value; null when isGlobal=true)"
+        }
+      }
+    ],
+    "claimableRoles": [
+      {
+        "name": "string (claimable role name)",
+        "type": "string (optional)",
+        "scope": { ... }
+      }
+    ]
+  }
+}
+```
+
+**Note**: The binding diff in dry-run output shows exactly which roles/groups are added or removed.
+
+**Example — global role binding:**
+```json
+{
+  "identifier": "admins-global-binding",
+  "system": "my-service",
+  "type": "EntraGroup",
+  "sourceSystem": "Entra",
+  "binding": {
+    "group": { "id": "04a439f6-cfc2-430b-8345-77d5a0151ef7" },
+    "roles": [
+      {
+        "name": "project-editor",
+        "scope": { "isGlobal": true }
+      }
+    ]
+  }
+}
+```
+
+**Example — scoped role binding:**
+```json
+{
+  "identifier": "project-alpha-editors",
+  "system": "my-service",
+  "type": "EntraGroup",
+  "sourceSystem": "Entra",
+  "binding": {
+    "group": { "id": "04a439f6-cfc2-430b-8345-77d5a0151ef7" },
+    "roles": [
+      {
+        "name": "project-editor",
+        "scope": {
+          "scopeTypeIdentifier": "project",
+          "isGlobal": false,
+          "value": "project-alpha"
+        }
+      }
+    ]
+  }
+}
+```
+
+---
+
+## RoleAssignment
+
+A direct role assignment for a specific identity.
+
+```json
+{
+  "roleIdentifier": "string (required — role name)",
+  "accountIdentifier": "string (optional — email or UPN)",
+  "source": "string (e.g. 'Entra')",
+  "externalIdentifier": "string (object ID from source system)",
+  "reason": "string (optional)",
+  "type": "string (optional — e.g. 'Direct')",
+  "scope": {
+    "scopeTypeIdentifier": "string (optional)",
+    "isGlobal": "boolean (optional)",
+    "value": "string (scope value; null when isGlobal=true)"
+  },
+  "validFrom": "ISO 8601 datetime (optional)",
+  "validTo": "ISO 8601 datetime (optional)",
+  "tags": [ "string" ]
+}
+```
+
+**Unique key**: `roleName` + `source` + `externalIdentifier`
+**Behaviour**: Create if missing; skip if exists. No partial updates.
+
+**Example:**
+```json
+{
+  "roleIdentifier": "project-editor",
+  "accountIdentifier": "user@equinor.com",
+  "source": "Entra",
+  "externalIdentifier": "12345678-1234-1234-1234-123456789012",
+  "scope": {
+    "scopeTypeIdentifier": "project",
+    "isGlobal": false,
+    "value": "project-alpha"
+  }
+}
+```
+
+---
+
+## ClaimableRoleAssignment
+
+Same structure as `RoleAssignment` but uses `claimableRoleIdentifier`:
+
+```json
+{
+  "claimableRoleIdentifier": "string (required — claimable role name)",
+  "accountIdentifier": "string (optional)",
+  "source": "string",
+  "externalIdentifier": "string",
+  "scope": { ... },
+  "validFrom": "ISO 8601 datetime (optional)",
+  "validTo": "ISO 8601 datetime (optional)",
+  "tags": [ "string" ]
+}
+```
+
+---
+
+## DeleteRoleAssignmentRequest
+
+Used in `deleteRoleAssignments` to remove specific assignments by ID (ID obtained from export):
+
+```json
+{
+  "roleIdentifier": "string (required — role name)",
+  "assignmentId": "string (required — assignment ID from API)"
+}
+```
+
+---
+
+## Complete example
+
+```json
+{
+  "$schema": "https://rolesv2.api.fusion.equinor.com/public/schemas/role-config.schema.json",
+  "scopeTypes": [
+    { "name": "project", "description": "Project scope" }
+  ],
+  "accessRoles": [
+    {
+      "systemIdentifier": "my-service",
+      "name": "MyService.Project.Read",
+      "description": "Read project resources",
+      "scopeTypeIdentifier": "project"
+    },
+    {
+      "systemIdentifier": "my-service",
+      "name": "MyService.Project.Write",
+      "description": "Write project resources",
+      "scopeTypeIdentifier": "project"
+    }
+  ],
+  "roles": [
+    {
+      "name": "project-viewer",
+      "displayName": "Project Viewer",
+      "accessRoleMappings": [
+        { "accessRoleIdentifier": "MyService.Project.Read" }
+      ]
+    },
+    {
+      "name": "project-editor",
+      "displayName": "Project Editor",
+      "accessRoleMappings": [
+        { "accessRoleIdentifier": "MyService.Project.Read" },
+        { "accessRoleIdentifier": "MyService.Project.Write" }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "identifier": "editors-entra-binding",
+      "system": "my-service",
+      "type": "EntraGroup",
+      "sourceSystem": "Entra",
+      "binding": {
+        "group": { "id": "04a439f6-cfc2-430b-8345-77d5a0151ef7" },
+        "roles": [
+          {
+            "name": "project-editor",
+            "scope": { "isGlobal": true }
+          }
+        ]
+      }
+    }
+  ]
+}
+```


### PR DESCRIPTION
## Why

The `fusion-infra-cli` (`finf`) and `fusion-roles-cli` (`froles`) CLI tools are used in Fusion Core Services CI/CD pipelines for database provisioning and role config deployment respectively. No Copilot agent skills exist for either, leaving agents without guidance when asked to provision a database or deploy role configuration.

## Current behavior

Agents have no skill to reference when working with `finf` or `froles`. Common tasks like "provision the PR database" or "deploy roles from this config file" require manual context gathering.

## New behavior

Two new skills added:

**`fusion-infra-cli`** — Focused on database provisioning workflows:
- Core workflow for `database provision` across `ci`, `fqa`, `fprd`, and PR ephemeral environments
- `database migrate` workflow
- DB config JSON schema in `references/db-config-schema.md`
- Links to source README and `--help` rather than duplicating flag tables (avoids drift)

**`fusion-roles-cli`** — Focused on deploying Roles V2 config from JSON files:
- Core `create` (idempotent), `--dry-run`, and `export` workflows
- Reconciliation behaviour documented (especially the access role mapping warning)
- Full role config JSON schema in `references/role-config-schema.md` covering all resource types: scope types, access roles, roles, claimable roles, bindings, assignments
- References the live canonical schema URL (`rolesv2.api.fusion.equinor.com`) and source docs rather than duplicating command flags

## References

- Issue(s): n/a
- Related PR(s): n/a
- Docs / specs:
  - [infra-cli README](https://github.com/equinor/fusion-core-services/blob/main/tooling/fusion-infra-cli/Fusion.Infra.Cli/README.md)
  - [roles-cli USING_CREATE_COMMAND.md](https://github.com/equinor/fusion-core-services/blob/main/tooling/fusion-roles-cli/Fusion.Roles.Cli/USING_CREATE_COMMAND.md)
  - [Live roles schema](https://rolesv2.api.fusion.equinor.com/public/schemas/role-config.schema.json)

## Reviewer focus

- Start here: `skills/fusion-infra-cli/SKILL.md`, `skills/fusion-roles-cli/SKILL.md`
- Verify the role config schema in `references/role-config-schema.md` matches the live schema
- Check that activation cues (description field) are distinct enough from each other and from existing skills
- Risky or security-sensitive parts: none — documentation only, no scripts

## Self review checklist

- [x] I scoped this PR to one clear purpose.
- [x] I followed [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I did not include secrets, credentials, or sensitive data.
- [x] I reviewed my own diff for clarity and unintended changes.

## Validation evidence

```
npx -y skills add . --list   ✓ (34 skills listed, both new skills present)
bun run validate:skills      ✓ Skill count check passed (34/34)
bun run validate:ownership   ✓ Ownership validation: 34/34 skills passed
bun run biome:check          ✓ No fixes applied
```
