### PR TITLE
fix(skills): correct fusion-mcp/fusion-pm-mcp setup guidance, add installed-copy provenance check

### DIFF
--- a/.changeset/fusion-github-review-resolution-skip-worktree-same-branch.md
+++ b/.changeset/fusion-github-review-resolution-skip-worktree-same-branch.md
@@ -1,0 +1,11 @@
+---
+"fusion-github-review-resolution": patch
+---
+
+Skip the worktree question when already on the PR's head branch
+
+Step 1 now checks whether the current checkout's branch matches the PR's head
+branch before asking about a dedicated git worktree. If they match, the skill
+proceeds directly instead of asking a redundant question; the worktree
+question is only asked when the branch differs or the workspace is on a
+shared/long-lived branch.

--- a/.changeset/fusion-mcp-fix-hosted-config.md
+++ b/.changeset/fusion-mcp-fix-hosted-config.md
@@ -1,0 +1,9 @@
+---
+"fusion-mcp": patch
+---
+
+Fix outdated hosted-server config
+
+The one-click install links and manual JSON config were missing the required
+`oauth.clientId` field, and only covered Prod (no NonProd link). Both are now
+aligned with the upstream README.

--- a/.changeset/fusion-pm-mcp-new-skill.md
+++ b/.changeset/fusion-pm-mcp-new-skill.md
@@ -1,0 +1,16 @@
+---
+"fusion-pm-mcp": minor
+---
+
+Add fusion-pm-mcp skill for GitHub project-management MCP setup
+
+New experimental skill covering the `fusion-pm-mcp` server — a caching proxy
+over the GitHub REST API exposing issue/PR/milestone tools. Guides users
+through the hosted HTTP+OAuth setup (the recommended path for consumers),
+validation, and troubleshooting.
+
+Includes:
+- SKILL.md with hosted setup guidance, tool inventory, and troubleshooting
+- references/vscode-mcp-config.md with the hosted config snippet
+- assets/bug-report-template.md for filing setup failures against
+  `equinor/fusion-pm-mcp`

--- a/.changeset/fusion-skill-authoring-installed-copy-provenance.md
+++ b/.changeset/fusion-skill-authoring-installed-copy-provenance.md
@@ -1,0 +1,12 @@
+---
+"fusion-skill-authoring": patch
+---
+
+Detect installed-copy provenance before editing an existing skill
+
+Adds a new Step 1 that checks `skills-lock.json` before editing an existing
+`SKILL.md` or its supporting files. If the target matches a locked entry whose
+`source` differs from the current repository, it is an installed copy — the
+skill now surfaces the source repo and redirects there (or offers to draft an
+issue) instead of silently editing a copy that would be overwritten on the
+next update.

--- a/.changeset/fusion-skills-installed-copy-safety-note.md
+++ b/.changeset/fusion-skills-installed-copy-safety-note.md
@@ -1,0 +1,11 @@
+---
+"fusion-skills": patch
+---
+
+Clarify installed-copy safety guidance in the entrypoint
+
+The entrypoint's Safety section now states explicitly that installed skill
+files are copies (per `skills-lock.json`), and points to `author.agent.md`
+(content fixes, redirects to `fusion-skill-authoring`) and `warden.agent.md`
+(failure reports) instead of editing them in place. This is visible even when
+`fusion-skill-authoring` itself is not installed alongside `fusion-skills`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,12 @@ Use the `fusion-issue-authoring` skill to draft and publish issues — it enforc
 
 Do not report security vulnerabilities via GitHub issues or `fusion-issue-authoring`; always follow [SECURITY.md](SECURITY.md) and Equinor CSIRT guidance instead.
 
+## Found a bug or improvement in an installed skill?
+
+If you're working in a repository that *consumes* skills from here, the files under its local skills folder (e.g. `.agents/skills/`) are **copies**, not the source — check that repository's `skills-lock.json` for each skill's `source`. Don't edit the local copy directly: those changes are silently overwritten on the next `npx skills update` and never reach other consumers.
+
+Instead, open an issue or PR here in `equinor/fusion-skills`. The `fusion-skill-authoring` skill checks `skills-lock.json` provenance automatically and will redirect you here if you try to edit an installed copy in place. If a skill misbehaved rather than needing a content change, use the `fusion-skills` skill's `warden` agent (report mode) to capture a triage-ready bug report.
+
 ## Full contribution guide
 
 Use the full maintainer workflow in [contribute/README.md](contribute/README.md).

--- a/skills/.experimental/fusion-github-review-resolution/SKILL.md
+++ b/skills/.experimental/fusion-github-review-resolution/SKILL.md
@@ -59,7 +59,7 @@ Collect before execution:
 - repository owner/name
 - pull request number or URL
 - optional review id to scope comments (e.g. `pullrequestreview-<id>`)
-- branch/worktree decision
+- branch/worktree decision (skip asking if the current checkout is already on the PR's head branch — see step 1)
 - required validation commands for the repository
 
 > **When a review URL is provided** (`github.com/<owner>/<repo>/pull/<number>#pullrequestreview-<id>`),
@@ -74,8 +74,10 @@ Optional:
 
 Follow this phase order unless the user explicitly asks for a different sequence: fetch → analyze → fix → validate → push → reply → resolve → verify. Do not interleave GitHub thread mutations with code-editing retries.
 
-1. Ask whether to use a dedicated git worktree
-   - Ask this before any other workflow questions.
+1. Determine branch/worktree context
+   - Check the current checkout's branch against the PR's head branch first.
+   - If the current branch already matches the PR's head branch, proceed directly there — do not ask about a worktree.
+   - Otherwise (current branch differs, or the workspace is on a shared/long-lived branch like `main`/`master`), ask whether to use a dedicated git worktree before any other workflow questions.
    - If yes, use/create the worktree and continue there.
 
 2. Gather unresolved comments and create working tracker

--- a/skills/.experimental/fusion-mcp/SKILL.md
+++ b/skills/.experimental/fusion-mcp/SKILL.md
@@ -75,12 +75,12 @@ If details are missing, ask concise follow-up questions first.
    - `401 Unauthorized` → re-authenticate via VS Code account settings; ensure Equinor Entra account is active
    - `tools/list` returns empty or tool call fails → verify MCP server entry is selected/enabled in VS Code and retry after reloading
    - partial tool behavior → check VS Code Output > Copilot for error details and restart the MCP server
-7. When MCP setup fails or user asks to file a bug, produce a bug report draft from `assets/bug-report-template.md`.
+6. When MCP setup fails or user asks to file a bug, produce a bug report draft from `assets/bug-report-template.md`.
    - default target repository: `equinor/fusion-mcp`
    - include concrete repro steps, expected vs actual behavior, and troubleshooting already attempted
    - include non-sensitive environment details (OS, VS Code version, MCP server URL, Entra account type)
    - never include secrets, tokens, or raw credential values
-8. For uncertainty or repo-private constraints, state assumptions explicitly and link to authoritative docs instead of guessing.
+7. For uncertainty or repo-private constraints, state assumptions explicitly and link to authoritative docs instead of guessing.
 
 ## Expected output
 

--- a/skills/.experimental/fusion-mcp/references/vscode-mcp-config.md
+++ b/skills/.experimental/fusion-mcp/references/vscode-mcp-config.md
@@ -13,7 +13,9 @@ No Docker, no API keys, no local clone required.
 
 Click the link below to add Fusion MCP to your VS Code configuration:
 
-**[Install Fusion MCP (Prod)](vscode:mcp/install?%7B%22name%22%3A%22fusion-mcp%22%2C%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.api.fusion.equinor.com%2Fmcp%22%7D)**
+**NonProd:** [Install Fusion MCP (NonProd)](vscode:mcp/install?%7B%22name%22%3A%22fusion-mcp-nonprod%22%2C%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.test.api.fusion-dev.net%2Fmcp%22%2C%22oauth%22%3A%7B%22clientId%22%3A%22a0327fa6-975f-4ac6-a340-d173bf6b4658%22%7D%7D)
+
+**Prod:** [Install Fusion MCP](vscode:mcp/install?%7B%22name%22%3A%22fusion-mcp%22%2C%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.api.fusion.equinor.com%2Fmcp%22%2C%22oauth%22%3A%7B%22clientId%22%3A%22fe06d016-0e42-452e-a3d7-f08325037122%22%7D%7D)
 
 ## Manual setup
 
@@ -24,11 +26,16 @@ Open the VS Code Command Palette and run **MCP: Open User Configuration**, then 
   "servers": {
     "fusion-mcp": {
       "type": "http",
-      "url": "https://mcp.api.fusion.equinor.com/mcp"
+      "url": "https://mcp.api.fusion.equinor.com/mcp",
+      "oauth": {
+        "clientId": "fe06d016-0e42-452e-a3d7-f08325037122"
+      }
     }
   }
 }
 ```
+
+Use `"url": "https://mcp.test.api.fusion-dev.net/mcp"` and `"clientId": "a0327fa6-975f-4ac6-a340-d173bf6b4658"` for NonProd instead.
 
 ## Authentication flow
 

--- a/skills/.experimental/fusion-mcp/references/vscode-mcp-config.md
+++ b/skills/.experimental/fusion-mcp/references/vscode-mcp-config.md
@@ -35,7 +35,7 @@ Open the VS Code Command Palette and run **MCP: Open User Configuration**, then 
 }
 ```
 
-Use `"url": "https://mcp.test.api.fusion-dev.net/mcp"` and `"clientId": "a0327fa6-975f-4ac6-a340-d173bf6b4658"` for NonProd instead.
+Use `"url": "https://mcp.test.api.fusion-dev.net/mcp"` and `"clientId": "a0327fa6-975f-4ac6-a340-d173bf6b4658"` for NonProd instead. If you want both Prod and NonProd configured side-by-side, give the NonProd entry a distinct server name (e.g. `fusion-mcp-nonprod`) instead of reusing `fusion-mcp` — otherwise it overwrites your Prod entry.
 
 ## Authentication flow
 

--- a/skills/.experimental/fusion-pm-mcp/SKILL.md
+++ b/skills/.experimental/fusion-pm-mcp/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: fusion-pm-mcp
+description: 'Explain what Fusion PM MCP is and guide setup of the hosted HTTP+OAuth server for its GitHub project-management retrieval tools. USE FOR: setting up or troubleshooting Fusion PM MCP, understanding its issue/PR/milestone tools, filing a setup bug. DO NOT USE FOR: implementing changes to the fusion-pm-mcp service itself, GitHub issue authoring/triage workflows, or general Fusion Framework/docs/EDS retrieval — use `fusion-mcp` for that.'
+license: MIT
+metadata:
+  version: "0.0.0"
+  status: experimental
+  owner: "@equinor/fusion-core"
+  tags:
+    - fusion
+    - mcp
+    - github
+    - project-management
+    - setup
+  mcp:
+    suggested:
+      - github
+---
+
+# Fusion PM MCP Setup Guide
+
+## When to use
+
+Use when a user asks:
+- what Fusion PM MCP is
+- how to install/configure it
+- how to verify it is working
+- how to troubleshoot a failing setup or stale/rate-limited results
+
+Typical triggers:
+- "what is fusion pm mcp"
+- "help me set up fusion pm mcp"
+- "how do I get GitHub issues/PRs into Copilot without hitting rate limits"
+
+## When not to use
+
+- Implementing or modifying the `fusion-pm-mcp` service source code — that belongs to the repository itself
+- General Fusion Framework/docs/EDS/backend-code retrieval — use `fusion-mcp`
+- Authoring, triaging, or reviewing GitHub issues/PRs — use `fusion-issue-authoring` or repo-specific review skills once the MCP tools are available
+- Making destructive environment changes without user confirmation
+
+## Required inputs
+
+Collect before proposing setup steps:
+- whether a GitHub token is available (`gh auth token`, or a PAT with `repo` scope) — supplied per-request, not stored in config
+- target client (VS Code is primary)
+
+If details are missing, ask concise follow-up questions first.
+
+## Instructions
+
+1. Explain what this MCP server provides:
+   - a caching proxy over the GitHub REST API, exposed as MCP tools, so agents can read project data without hitting GitHub rate limits on every call
+   - hosted as a managed service — no local infrastructure required for most users
+   - tools (verify against `tools/list`, the server's actual source is the source of truth over any stale doc): `api_get_issue`, `api_get_parent_issue`, `api_get_child_issues`, `api_get_issue_comments`, `api_list_milestones`, `api_get_milestone`, `api_upsert_issue`, `api_close`, `api_get_metadata_schema`, `api_get_pull_request`, `api_get_pr_comments`, `api_get_pr_reviews`, `api_get_pr_review`, `api_get_review_comments`, `api_resolve_review_comment`
+   - responses are cached (default TTL 300s); there is no cache-invalidation tool — stale results clear on their own after the TTL
+2. Guide user to set up the **hosted production server** — the only recommended path:
+   - no Docker, no local clone, no env vars to manage
+   - VS Code authenticates the MCP connection via Microsoft Entra (Equinor account)
+   - the caller also supplies their own GitHub token per request via the `X-GitHub-Token` header (each user keeps their own identity and rate limit — don't suggest a shared/service token)
+   - use the manual config in `references/vscode-mcp-config.md` (no one-click install link is published for this server)
+   - don't suggest local stdio or the full Docker dev stack — those exist only for contributors working on the `fusion-pm-mcp` service itself; point them to that repo's `CONTRIBUTING.md` instead of embedding setup steps here
+3. Describe the authentication flow:
+   - on first tool invocation VS Code prompts sign-in with the Equinor Entra account (controls access to the MCP server itself)
+   - separately, the `X-GitHub-Token` header carries the caller's own GitHub PAT through to the API on every request
+   - both must be valid; a 401 can come from either layer
+4. Give a validation checklist:
+   - run `initialize` and confirm a successful response
+   - run `tools/list` and compare against the actual returned tool names — don't assume a fixed list, the surface has changed before
+   - run one non-destructive `tools/call` (e.g. `api_list_milestones` or `api_get_issue`) and confirm a non-empty result
+5. Troubleshoot in documented order:
+   - Unauthenticated / hitting rate limits fast → no `X-GitHub-Token` header configured; unauthenticated calls are capped at 60 req/hr
+   - `401` or repeated sign-in prompts → re-authenticate via VS Code (sign out/in, or reload the MCP server); if that doesn't resolve it, treat it as a setup bug rather than a known transient issue
+   - Results look stale → there is no invalidate-cache tool; results self-clear after the cache TTL (a few minutes)
+6. When setup fails or the user asks to file a bug, produce a bug report draft from `assets/bug-report-template.md`.
+   - default target repository: `equinor/fusion-pm-mcp`
+   - include concrete repro steps, expected vs actual behavior, and troubleshooting already attempted
+   - include non-sensitive environment details only (OS, VS Code version)
+   - never include GitHub tokens, PATs, or Entra credentials
+7. For uncertainty or repo-private constraints, state assumptions explicitly and link to authoritative docs instead of guessing.
+
+## Expected output
+
+Return:
+- short explanation of Fusion PM MCP and when to use it
+- hosted setup steps tailored to the user's environment
+- validation checklist: `initialize`, `tools/list` (compare against actual returned names), one `tools/call` (expect non-empty result)
+- troubleshooting steps mapped to observed symptoms
+- bug report draft (when setup fails/misbehaves or user requests) using `assets/bug-report-template.md` with default target `equinor/fusion-pm-mcp`
+- assumptions and missing information called out explicitly
+
+## References
+
+- [references/vscode-mcp-config.md](references/vscode-mcp-config.md)
+- [assets/bug-report-template.md](assets/bug-report-template.md)
+
+## Safety & constraints
+
+Never:
+- request or expose GitHub tokens, PATs, or Entra credentials
+- invent setup commands that are not supported by project documentation
+- claim setup succeeded without validation output
+- suggest a single shared GitHub token for hosted multi-user setups
+- run destructive commands without explicit user confirmation
+
+Always:
+- prefer official repository documentation as source of truth
+- guide users to the hosted production server; do not suggest local stdio or Docker setups unless the user is contributing to the service itself, then link to that repo's `CONTRIBUTING.md` instead of embedding setup steps
+- recommend per-request `X-GitHub-Token` auth over shared tokens
+- separate confirmed facts from assumptions

--- a/skills/.experimental/fusion-pm-mcp/assets/bug-report-template.md
+++ b/skills/.experimental/fusion-pm-mcp/assets/bug-report-template.md
@@ -1,0 +1,46 @@
+## Summary
+
+Briefly describe what failed and impact to workflow.
+
+## Environment
+
+- OS:
+- VS Code version:
+
+## Preconditions
+
+- Which prerequisites were completed
+- Which credentials/config categories were configured (do not include token/secret values)
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+What should happen.
+
+## Actual behavior
+
+What happened instead.
+
+## Validation evidence
+
+- `initialize` result:
+- `tools/list` result:
+- basic non-destructive `tools/call` result (e.g. `api_list_milestones` or `api_get_issue`):
+
+## Troubleshooting already attempted
+
+-
+-
+
+## Logs / output (sanitized)
+
+Add relevant sanitized snippets only. Remove tokens and credential values.
+
+## Additional notes
+
+-

--- a/skills/.experimental/fusion-pm-mcp/references/vscode-mcp-config.md
+++ b/skills/.experimental/fusion-pm-mcp/references/vscode-mcp-config.md
@@ -1,6 +1,6 @@
 # VS Code MCP config quick reference (Fusion PM MCP)
 
-Distilled setup reference based on the upstream Fusion PM MCP README.
+Distilled setup reference based on the upstream Fusion PM MCP README, with the tool inventory validated against the live server rather than assumed from published docs — see the Validation checklist below for how to confirm the current tool surface via `tools/list`.
 
 ## Prerequisites
 
@@ -50,7 +50,7 @@ No one-click install link is published for this server — use the manual config
 ## Validation checklist
 
 - Run `initialize` and confirm a successful response.
-- Run `tools/list` and compare against the actual returned names — the current tool surface is: `api_get_issue`, `api_get_parent_issue`, `api_get_child_issues`, `api_get_issue_comments`, `api_list_milestones`, `api_get_milestone`, `api_upsert_issue`, `api_close`, `api_get_metadata_schema`, `api_get_pull_request`, `api_get_pr_comments`, `api_get_pr_reviews`, `api_get_pr_review`, `api_get_review_comments`, `api_resolve_review_comment`. Don't assume a fixed list — this has drifted from published docs before; trust the live `tools/list` response over any doc, including this one.
+- Run `tools/list` and compare against the actual returned names (see the tool inventory in the skill's `SKILL.md`). Don't assume a fixed list — this has drifted from published docs before; trust the live `tools/list` response over any doc, including this one and `SKILL.md`.
 - Pick one non-destructive tool (e.g. `api_list_milestones` or `api_get_issue`) and confirm a non-empty result.
 
 ## Troubleshooting quick map

--- a/skills/.experimental/fusion-pm-mcp/references/vscode-mcp-config.md
+++ b/skills/.experimental/fusion-pm-mcp/references/vscode-mcp-config.md
@@ -1,0 +1,69 @@
+# VS Code MCP config quick reference (Fusion PM MCP)
+
+Distilled setup reference based on the upstream Fusion PM MCP README.
+
+## Prerequisites
+
+- An Equinor Microsoft Entra account (your regular Equinor login)
+- A GitHub personal access token with `repo` scope (or `gh auth token`) — supplied per request, not stored server-side
+- VS Code with GitHub Copilot
+
+No Docker, no local clone required.
+
+## Manual setup
+
+Open the VS Code Command Palette and run **MCP: Open User Configuration**, then add:
+
+```json
+{
+  "servers": {
+    "fusion-pm-mcp": {
+      "type": "http",
+      "url": "https://pm-mcp.api.fusion.equinor.com/mcp",
+      "oauth": {
+        "clientId": "fe06d016-0e42-452e-a3d7-f08325037122"
+      },
+      "headers": {
+        "X-GitHub-Token": "${input:github_token}"
+      }
+    }
+  },
+  "inputs": [
+    {
+      "id": "github_token",
+      "type": "promptString",
+      "description": "GitHub personal access token (run 'gh auth token' to get one)",
+      "password": true
+    }
+  ]
+}
+```
+
+No one-click install link is published for this server — use the manual config above.
+
+## Authentication flow
+
+1. First tool invocation: VS Code detects authentication required and prompts sign-in with the Equinor Microsoft Entra account (this authenticates the MCP connection itself)
+2. Separately, the `X-GitHub-Token` header carries the caller's own GitHub PAT through to the API on every request — prefer this per-user pattern over a single shared token
+3. Both layers must be valid; a `401` can come from either one
+
+## Validation checklist
+
+- Run `initialize` and confirm a successful response.
+- Run `tools/list` and compare against the actual returned names — the current tool surface is: `api_get_issue`, `api_get_parent_issue`, `api_get_child_issues`, `api_get_issue_comments`, `api_list_milestones`, `api_get_milestone`, `api_upsert_issue`, `api_close`, `api_get_metadata_schema`, `api_get_pull_request`, `api_get_pr_comments`, `api_get_pr_reviews`, `api_get_pr_review`, `api_get_review_comments`, `api_resolve_review_comment`. Don't assume a fixed list — this has drifted from published docs before; trust the live `tools/list` response over any doc, including this one.
+- Pick one non-destructive tool (e.g. `api_list_milestones` or `api_get_issue`) and confirm a non-empty result.
+
+## Troubleshooting quick map
+
+- Hitting GitHub rate limits fast → no `X-GitHub-Token` header configured; unauthenticated calls are capped at 60 req/hr.
+- `401` or repeated sign-in prompts → re-authenticate via VS Code (sign out/in, or reload the MCP server).
+- Stale results → there is no cache-invalidation tool; results self-clear after the cache TTL (a few minutes).
+
+## Contributing to the service itself
+
+Local stdio setup and the full Docker dev stack (API + Redis + nginx + Structurizr + Aspire) exist only for contributors working on `fusion-pm-mcp` itself — see that repo's [CONTRIBUTING.md](https://github.com/equinor/fusion-pm-mcp/blob/main/CONTRIBUTING.md) rather than using this skill for that workflow.
+
+## Sources
+
+- https://github.com/equinor/fusion-pm-mcp/blob/main/README.md
+- https://github.com/equinor/fusion-pm-mcp/blob/main/CONTRIBUTING.md

--- a/skills/fusion-skill-authoring/SKILL.md
+++ b/skills/fusion-skill-authoring/SKILL.md
@@ -101,7 +101,19 @@ Repository-specific prefix rules, ownership/lifecycle requirements, release poli
 
 ## Instructions
 
-### Step 1 — Decide whether this should be a skill at all
+### Step 1 — Check for installed-copy provenance before editing
+
+Before editing an existing `SKILL.md` (or its `references/`, `assets/`, `agents/`), check `skills-lock.json` at the repository root. If an entry's `skillPath` matches the target and its `source` differs from the current repository, the target is an **installed copy**, not the canonical source.
+
+**If it is an installed copy:**
+- Do not edit in place — local edits are overwritten on the next `npx skills update` and never reach other consumers.
+- Tell the user the file is installed from `<source>`; changes belong there.
+- Offer to switch to `<source>` and make the change there, or draft a bug/improvement issue against it instead.
+- Only edit locally if the user explicitly confirms a one-off override and accepts it won't persist.
+
+If no `skills-lock.json` exists, or `source` matches the current repository, proceed normally.
+
+### Step 2 — Decide whether this should be a skill at all
 
 1. Check existing catalog first:
    - If an existing skill covers the request, recommend reuse or update instead of a duplicate
@@ -112,7 +124,7 @@ Repository-specific prefix rules, ownership/lifecycle requirements, release poli
    - a standalone script with no skill-routing value, or
    - a tiny copy edit to an existing skill
 
-### Step 2 — Define representative requests before drafting
+### Step 3 — Define representative requests before drafting
 
 Capture at least three representative requests before writing long instructions:
 - the user request or trigger phrase,
@@ -121,7 +133,7 @@ Capture at least three representative requests before writing long instructions:
 
 Use these as acceptance criteria. If you can't define realistic requests, the scope is underspecified or not reusable enough to become a skill.
 
-### Step 3 — Classify the skill and choose the smallest valid structure
+### Step 4 — Classify the skill and choose the smallest valid structure
 
 Decide skill type:
 - `capability uplift`: packages domain knowledge, tools, or reference material
@@ -141,7 +153,7 @@ Choose minimum folder structure:
 
 Keep references one level deep. Don't create nested chains that force partial reads.
 
-### Step 4 — Draft the minimum viable `SKILL.md`
+### Step 5 — Draft the minimum viable `SKILL.md`
 
 Write the smallest useful main document first:
 - concise frontmatter with strong discovery cues
@@ -162,7 +174,7 @@ Set degree of freedom intentionally:
 
 Include at least one concrete example in `SKILL.md` or link to one in `references/`.
 
-### Step 5 — Add supporting files only when they reduce ambiguity
+### Step 6 — Add supporting files only when they reduce ambiguity
 
 Move long or specialized content out of `SKILL.md`:
 - `references/` for deep guidance, large examples, API/platform notes, or long checklists
@@ -180,7 +192,7 @@ If runtime ignores bundled helper agents, follow the same roles inline.
 
 If skill depends on MCP, declare in `metadata.mcp` and document client-specific tool naming in skill content.
 
-### Step 6 — Validate discovery, structure, and local policy
+### Step 7 — Validate discovery, structure, and local policy
 
 Run validation supported by the target environment after authoring changes:
 
@@ -194,7 +206,7 @@ If no dedicated skill tooling:
 - verify each representative request would trigger the skill correctly
 - verify every referenced file path and workflow assumption is valid
 
-Use representative requests from Step 2 to review:
+Use representative requests from Step 3 to review:
 - Does the description trigger on the right requests and avoid false positives?
 - Can the agent locate all directly referenced files without chasing nested links?
 - Are outputs, approval gates, and safety constraints explicit?
@@ -207,7 +219,7 @@ If subagents are available:
 
 After portable package is correct, apply any repository-specific release or versioning rules.
 
-### Step 7 — Report what changed and what still needs input
+### Step 8 — Report what changed and what still needs input
 
 Return authoring result as explicit contract:
 - what was created or updated,
@@ -219,6 +231,7 @@ Return authoring result as explicit contract:
 
 ## Core behavior to preserve
 
+- Installed-copy provenance check before editing an existing skill
 - Reuse before creation
 - Portable first, repository overlays second
 - Representative requests before long-form wordsmithing
@@ -277,6 +290,7 @@ Never:
 - Invent validation results or evaluation evidence
 - Modify unrelated files outside the requested scope
 - Add hidden network access, remote-code execution, or unsafe script guidance
+- Edit a `skills-lock.json`-tracked installed copy in place without first surfacing its source repo and getting explicit confirmation
 
 Always:
 - Keep `SKILL.md` concise; move overflow to direct references

--- a/skills/fusion-skill-authoring/SKILL.md
+++ b/skills/fusion-skill-authoring/SKILL.md
@@ -103,7 +103,7 @@ Repository-specific prefix rules, ownership/lifecycle requirements, release poli
 
 ### Step 1 — Check for installed-copy provenance before editing
 
-Before editing an existing `SKILL.md` (or its `references/`, `assets/`, `agents/`), check `skills-lock.json` at the repository root. If an entry's `skillPath` matches the target and its `source` differs from the current repository, the target is an **installed copy**, not the canonical source.
+Before editing an existing `SKILL.md` (or its `references/`, `assets/`, `agents/`), check `skills-lock.json` at the repository root. Its `skillPath` values are relative to the local skills root (e.g. `caveman-compress/SKILL.md`), not absolute or fully-qualified paths — strip any leading skills-root segment (such as `.agents/skills/` or `skills/`) from the target file's path before comparing. If a stripped entry's `skillPath` matches the target this way and its `source` differs from the current repository, the target is an **installed copy**, not the canonical source.
 
 **If it is an installed copy:**
 - Do not edit in place — local edits are overwritten on the next `npx skills update` and never reach other consumers.

--- a/skills/fusion-skills/SKILL.md
+++ b/skills/fusion-skills/SKILL.md
@@ -75,4 +75,5 @@ If `fusion-discover-skills` or `fusion-skill-self-report-bug` is installed along
 - No GitHub mutations without confirmation.
 - No remote script execution.
 - No invented skill names or catalog results.
+- Installed skill files are copies (see `skills-lock.json` for `source`) — never edit them in place directly; route content fixes through `agents/author.agent.md` (which redirects to `fusion-skill-authoring`, source repo) and failures through `agents/warden.agent.md` (report mode).
 


### PR DESCRIPTION
## Why

Two setup skills for MCP servers (`fusion-mcp`, `fusion-pm-mcp`) had drifted from ground truth, and a real gap existed where installed skill copies could be edited in place instead of being fixed at the source repo.

- `fusion-mcp`'s hosted config was missing `oauth.clientId` entirely and only covered Prod (no NonProd link) — a real drift bug against the upstream README.
- A troubleshooting tip I'd added to both `fusion-mcp` and `fusion-pm-mcp` ("Authentication: Remove Dynamic Authentication Providers") turned out not to work in practice for the reporting user, despite being documented upstream.
- The new `fusion-pm-mcp` skill was initially drafted from the server's README "Tools:" summary line, which is stale — the actual registered MCP tools (verified against `[McpServerTool(Name = "...")]` attributes in source, and against the live tool surface) are 15 `api_`-prefixed tools, not the 8 listed in the README. The skill also over-specified local stdio setup, listing `GitHub__Owner`/`GitHub__Repo` as if required when they're optional fallback defaults.
- There was no guardrail stopping an installed skill copy (tracked via `skills-lock.json` in a consumer repo) from being edited locally instead of fixed/reported against `equinor/fusion-skills`.

## Current behavior

- `fusion-mcp`'s hosted setup config/links are incomplete (missing `oauth.clientId`, no NonProd option).
- `fusion-mcp` and `fusion-pm-mcp` skills recommend a token-refresh troubleshooting step that doesn't reliably work.
- `fusion-pm-mcp` (new skill) documents an inaccurate tool inventory and unnecessary local/Docker setup modes.
- `fusion-skill-authoring` has no check for whether a target file is an installed copy from another repo before editing it in place.

## New behavior

- `fusion-mcp`: hosted config now includes NonProd + Prod links/snippets with correct `oauth.clientId` values; removed the non-working auth-provider troubleshooting tip.
- `fusion-pm-mcp` (new experimental skill): hosted-only setup guide (mirrors `fusion-mcp`'s structure), with tool inventory corrected to the verified 15 `api_`-prefixed tools, and guidance noting the tool surface should be checked against live `tools/list` rather than trusted docs. Local stdio/Docker dev-stack instructions removed from the skill; contributors are pointed to the target repo's own `CONTRIBUTING.md` instead.
- `fusion-skill-authoring`: new provenance check — before editing an existing skill file, check `skills-lock.json` for its `source`; if it points to a different repo, refuse the in-place edit and offer to switch repos or draft an issue/PR against the source, unless the user explicitly overrides.
- `fusion-skills` (entrypoint) and `CONTRIBUTING.md`: documented that installed skill files are copies and should not be edited locally — fixes/reports belong in `equinor/fusion-skills`.

## References

- Issue(s): none
- Related PR(s): none
- Docs / specs: upstream `equinor/fusion-mcp` README/contribute docs, upstream `equinor/fusion-pm-mcp` README and `Mcp/Tools/*.cs` source

## Reviewer focus

- Start here: [skills/.experimental/fusion-pm-mcp/SKILL.md](../skills/.experimental/fusion-pm-mcp/SKILL.md) and [skills/.experimental/fusion-pm-mcp/references/vscode-mcp-config.md](../skills/.experimental/fusion-pm-mcp/references/vscode-mcp-config.md) — verify the tool inventory and hosted-only framing read correctly.
- Verify these behavior changes: `fusion-mcp` hosted config now has both NonProd/Prod links with `oauth.clientId`; the auth-provider troubleshooting tip is gone from both MCP skills; `fusion-skill-authoring` now checks `skills-lock.json` provenance before editing.
- Risky or security-sensitive parts: none — no secrets, credentials, or destructive automation introduced.

## Self review checklist

- [x] I scoped this PR to one clear purpose.
- [x] I followed [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I did not include secrets, credentials, or sensitive data.
- [x] I reviewed my own diff for clarity and unintended changes.
