### PR TITLE
feat(fusion-design): sidemenu/nav/spacing references + action & layout references, typography and table-width fixes

### DIFF
--- a/.changeset/fusion-design-actions-and-layout-refs.md
+++ b/.changeset/fusion-design-actions-and-layout-refs.md
@@ -1,0 +1,11 @@
+---
+"fusion-design": patch
+---
+
+Add action and layout references; fix typography and table-width guidance
+
+- Add `references/actions.md`: action bar (experimental), destructive-action `Dialog` structure, and button placement rules
+- Add `references/layout-centered-content.md`: centered-content layout rules for form- and reading-heavy pages
+- `references/eds-typography.md`: document the grouped-variant trap — `cell_header`/`cell_text` require `group="table"` (passes typecheck but crashes at runtime without it); prefer group-free quick variants
+- `references/layout.md`: data tables and lists must fill the full content width (`width: 100%`) in the full-width pattern
+- `SKILL.md`: add `actions.md` to the references table

--- a/.changeset/fusion-design-sidemenu-reference-b3c72a1f.md
+++ b/.changeset/fusion-design-sidemenu-reference-b3c72a1f.md
@@ -1,0 +1,8 @@
+---
+"fusion-design": patch
+---
+
+Add sidemenu navigation reference
+
+- Add `references/navigation-sidemenu.md` with sidemenu structure, hierarchy, and breadcrumb rules
+- Update SKILL.md reference table to include the new navigation reference

--- a/.changeset/fusion-design-state-and-help-refs.md
+++ b/.changeset/fusion-design-state-and-help-refs.md
@@ -1,0 +1,5 @@
+---
+"fusion-design": patch
+---
+
+Add empty-states, error-messages, and contextual-help references (including the Tooltip double-tooltip guidance).

--- a/skills/.experimental/fusion-design/SKILL.md
+++ b/skills/.experimental/fusion-design/SKILL.md
@@ -27,6 +27,7 @@ This skill is a lookup. Read **all** reference files before writing any code —
 | Topic | File |
 |---|---|
 | EDS Typography | `references/eds-typography.md` |
+| Navigation — Sidemenu | `references/navigation-sidemenu.md` |
 
 ### 2. Check for a local `DESIGN.md`
 

--- a/skills/.experimental/fusion-design/SKILL.md
+++ b/skills/.experimental/fusion-design/SKILL.md
@@ -30,8 +30,12 @@ This skill is a lookup. Read **all** reference files before writing any code —
 | Navigation — Sidemenu | `references/navigation-sidemenu.md` |
 | Navigation — Tabs | `references/navigation-tabs.md` |
 | Layout — Content area patterns | `references/layout.md` |
+| Layout — Centered content | `references/layout-centered-content.md` |
 | Spacing | `references/spacing.md` |
 | Actions — Action bar, destructive actions, button placement | `references/actions.md` |
+| Empty states | `references/empty-states.md` |
+| Error messages | `references/error-messages.md` |
+| Contextual help (ℹ / ? icons, density) | `references/contextual-help.md` |
 
 ### 2. Check for a local `DESIGN.md`
 

--- a/skills/.experimental/fusion-design/SKILL.md
+++ b/skills/.experimental/fusion-design/SKILL.md
@@ -28,6 +28,9 @@ This skill is a lookup. Read **all** reference files before writing any code —
 |---|---|
 | EDS Typography | `references/eds-typography.md` |
 | Navigation — Sidemenu | `references/navigation-sidemenu.md` |
+| Navigation — Tabs | `references/navigation-tabs.md` |
+| Layout — Content area patterns | `references/layout.md` |
+| Spacing | `references/spacing.md` |
 
 ### 2. Check for a local `DESIGN.md`
 

--- a/skills/.experimental/fusion-design/SKILL.md
+++ b/skills/.experimental/fusion-design/SKILL.md
@@ -31,6 +31,7 @@ This skill is a lookup. Read **all** reference files before writing any code —
 | Navigation — Tabs | `references/navigation-tabs.md` |
 | Layout — Content area patterns | `references/layout.md` |
 | Spacing | `references/spacing.md` |
+| Actions — Action bar, destructive actions, button placement | `references/actions.md` |
 
 ### 2. Check for a local `DESIGN.md`
 

--- a/skills/.experimental/fusion-design/references/actions.md
+++ b/skills/.experimental/fusion-design/references/actions.md
@@ -1,0 +1,84 @@
+# Actions
+
+Rules for save/discard actions and destructive actions. Grounded in `docs/patterns/action-bar/`, `docs/patterns/destructive-actions.md`, and `docs/guidelines/ux-writing.md`.
+
+---
+
+## Action bar
+
+> **Status: experimental.** The action bar is not yet a ratified Fusion pattern and has no shared component in `fusion-react-components` — it is currently trialed in App Admin only. Treat this guidance as provisional: apply it when a page genuinely needs an explicit-save action bar, but do not proliferate the pattern as an established Fusion standard until it is ratified. The destructive-action and button-placement rules below are settled and apply regardless.
+
+Use a sticky action bar for any page with a form or editable content that requires an explicit **Save** (not auto-save).
+
+| Property | Value |
+|---|---|
+| Position | Sticky, directly below the page header |
+| Height | `50px` |
+| Horizontal padding | `--eds-spacing-inset-xl-horizontal` — the page/view tier, so the bar's status label and buttons align with the header title and page content edges. Never use the `md` container tier here |
+| Visibility | Hidden when idle — appears only when the user makes a change (dirty) |
+| Left zone | A plain colored bullet character (`●`) + status label — e.g. `● Unsaved changes`. Never use an EDS `Icon` component (`edit`, `pencil`, etc.) here — the source pattern uses a literal `●`/`✓`/`⚠` character, not an icon |
+| Right zone | `Discard` (ghost variant) + `Save` (primary), in that order — `Discard` must use `variant="ghost"`, never a filled/contained secondary button |
+
+- Never render an inline Save button elsewhere on the page — the action bar is the only way to persist changes
+- The bar disappears after a successful save and returns to idle
+- Do **not** use the action bar inside side panels — side panels use the Apply pattern with buttons below the panel content
+- Do **not** use the action bar for auto-saving forms — use a status indicator instead
+
+---
+
+## Destructive actions
+
+Never execute a destructive action (delete, remove, restore-to-default) directly from its trigger. Always confirm first.
+
+| Context | Confirmation mechanism |
+|---|---|
+| Full-page or list action (e.g. delete an entity) | EDS `Dialog` |
+| Inline action inside a side panel footer | Inline warning state replacing the footer row — not a `Dialog` |
+
+**EDS `Dialog` structure (required):** the EDS `Dialog` is compositional — its sub-components must be nested correctly or the dialog renders cramped and unstyled:
+
+```tsx
+<Dialog open={open} isDismissable onClose={onCancel}>
+  <Dialog.Header>
+    <Dialog.Title>Delete Project Alpha</Dialog.Title>
+  </Dialog.Header>
+  <Dialog.CustomContent>
+    <Typography variant="body_short">
+      This will permanently delete Project Alpha. This action cannot be undone.
+    </Typography>
+  </Dialog.CustomContent>
+  <Dialog.Actions>
+    {/* actions must sit in a flex row, right-aligned — otherwise buttons stack vertically */}
+    <div style={{ display: 'flex', gap: 'var(--eds-spacing-horizontal-xs)', justifyContent: 'flex-end' }}>
+      <Button variant="ghost" onClick={onCancel}>Keep</Button>
+      <Button color="danger" variant="outlined" onClick={onConfirm}>Delete</Button>
+    </div>
+  </Dialog.Actions>
+</Dialog>
+```
+
+- Always wrap `Dialog.Title` in `Dialog.Header` — placing `Dialog.Title` directly under `Dialog` loses the header padding.
+- Put body copy in `<Typography variant="body_short">` inside `Dialog.CustomContent` — never a raw `<p>`.
+- Lay out the buttons in `Dialog.Actions` in a right-aligned flex row — bare buttons stack vertically and misalign.
+- Do **not** set a fixed width on the action buttons or stretch them — let each button size to its own label. Combined with short labels (below) this keeps them on one line.
+
+**Dialog anatomy:**
+
+| Element | Guidance |
+|---|---|
+| Title | Names the subject, not a question — `Delete Project Alpha`, not `Are you sure?` |
+| Body | One sentence, active voice, states the consequence — `This will permanently delete Project Alpha. This action cannot be undone.` |
+| Safe action | Left button, ghost variant. When the title already names the subject, use the bare verb — `Keep` — not `Keep Project Alpha`. Never `Cancel`. |
+| Destructive action | Right button, danger/outlined-danger variant. When the title already names the subject, use the bare verb — `Delete` — not `Delete Project Alpha`. |
+
+- **Do not repeat the subject on the buttons when the dialog title already names it.** The title carries the subject (`Delete Project Alpha`); the buttons only need the verb (`Keep` / `Delete`). Repeating the full name on both buttons is redundant and causes multi-line wrapping. Outside a titled dialog (e.g. a standalone button with no naming context), name the subject — `Delete app`.
+- Never use a generic label — `OK`, `Cancel`, `Confirm`, `Yes`, `No` are not acceptable anywhere in the system
+- Never disable the destructive action behind typed confirmation unless the action is irreversible **and** high-impact (e.g. permanently deleting a shared resource) — a standard confirm/cancel dialog is sufficient otherwise
+
+---
+
+## Button placement
+
+- The button that executes the primary or destructive action always sits **rightmost**
+- Secondary/safe/cancel buttons sit to its **left**
+- Never place more than one destructive-variant button in the same row

--- a/skills/.experimental/fusion-design/references/contextual-help.md
+++ b/skills/.experimental/fusion-design/references/contextual-help.md
@@ -4,8 +4,10 @@ Two icons provide contextual help; both supplement good labelling — neither re
 
 | Icon | Level | Behaviour | Use for |
 |---|---|---|---|
-| **Info (ℹ)** | Content-level titles — section headings, form labels, card/table headers | Hover/click → short inline tooltip | Explaining a specific field or term the user may not understand |
+| **Info (ℹ)** | Content-level titles — section headings, form labels, card/table headers | Hover/focus → short inline tooltip (**not** clickable) | Explaining a specific field or term the user may not understand |
 | **Help (?)** | Page `h1` only | Click → opens the Fusion Help Center side sheet | Linking the page to a help article |
+
+The ℹ icon is **hover/focus only** — a plain EDS `Tooltip`, no click-to-toggle. Only the `?` icon responds to a click (it opens the Help Center).
 
 ---
 

--- a/skills/.experimental/fusion-design/references/contextual-help.md
+++ b/skills/.experimental/fusion-design/references/contextual-help.md
@@ -1,0 +1,59 @@
+# Contextual Help
+
+Two icons provide contextual help; both supplement good labelling — neither replaces it. Grounded in `docs/patterns/contextual-help-icons.md`.
+
+| Icon | Level | Behaviour | Use for |
+|---|---|---|---|
+| **Info (ℹ)** | Content-level titles — section headings, form labels, card/table headers | Hover/click → short inline tooltip | Explaining a specific field or term the user may not understand |
+| **Help (?)** | Page `h1` only | Click → opens the Fusion Help Center side sheet | Linking the page to a help article |
+
+---
+
+## Density — the most important rule
+
+Help icons are the **exception, not the default**. If everything needs explaining, the labels or layout need rethinking, not more icons.
+
+**Signs of over-use (avoid):**
+- Three or more ℹ visible at once in the same section or table
+- An ℹ on every column header
+- A `?` on a page whose `h1` is already self-explanatory
+
+**How to keep it sparse:**
+- Audit labels first — if rewording the label removes the need, do that instead of adding an icon.
+- Add ℹ only to the genuinely ambiguous fields; leave well-understood fields clean.
+- In data-heavy tables with many unfamiliar columns, prefer a **single column legend/glossary** over one ℹ per column.
+
+## Implementation (avoid the double-tooltip trap)
+
+Wrap the info icon in an EDS `Tooltip` — the tooltip supplies the description. Do **not** also set a `title` prop on the `Icon`: EDS `Icon`'s `title` renders an SVG `<title>`, which the browser shows as its **own** native tooltip. With both, two tooltips appear on hover (the EDS one *and* `About …`).
+
+```tsx
+// ✅ Correct — Tooltip provides the text; icon has no title
+<Tooltip title={helpText} placement="top">
+  <Icon data={info_circle} size={16} />
+</Tooltip>
+
+// ❌ Wrong — icon `title` + Tooltip = two overlapping tooltips
+<Tooltip title={helpText}>
+  <Icon data={info_circle} title={`About ${label}`} />
+</Tooltip>
+```
+
+## Placement & copy
+
+- Place the icon immediately to the right of the title text, vertically centred. **One icon per title.**
+- **Never** place an icon mid-sentence or inside body text — titles only.
+- **Never** put both ℹ and `?` on the same title — pick the right level.
+- Keep info-tooltip copy short (≈ ≤ 160 characters). If it needs more than two sentences, it's too long for a tooltip.
+- **Never** use a tooltip for critical must-read information — if the user must read it to proceed safely, it belongs in persistent visible copy.
+
+## Don'ts
+
+- Don't use an icon to compensate for a weak label — fix the label first.
+- Don't wire a `?` icon without a published help article — an empty side sheet is worse than no icon.
+- Don't truncate tooltip text.
+- Don't put a `title` on an icon that's already inside a `Tooltip` — it produces a duplicate native tooltip.
+
+## Accessibility
+
+- The icon must be keyboard-focusable so the tooltip can be triggered without a mouse, and the tooltip text must be reachable by screen readers.

--- a/skills/.experimental/fusion-design/references/eds-typography.md
+++ b/skills/.experimental/fusion-design/references/eds-typography.md
@@ -23,6 +23,23 @@ import { Typography } from '@equinor/eds-core-react';
 | Sub-section | `variant="h3"` |
 | Card/panel title | `variant="h4"` |
 
+## Grouped variants require a `group` prop (runtime-crash trap)
+
+`Typography` resolves most variants **only within a group**. The "quick" variants — `h1`–`h6`, `body_short`, `body_long`, `caption`, `overline`, `ingress` — work with **no** `group`. Every other variant (e.g. the `table` group's `cell_header`, `cell_text`, `cell_text_bold`) lives under a group and **must** be passed with its `group`, or the component throws at render time and blanks the page.
+
+This is a **type-check trap**: the variant name is in the TypeScript union, so `tsc` and the build pass — but `<Typography variant="cell_header">` crashes in the browser with `Cannot read properties of undefined (reading 'cell_header')`.
+
+```tsx
+// ❌ Wrong — grouped variant with no group: passes tsc/build, CRASHES at runtime (blank page)
+<Typography variant="cell_header">Tag</Typography>
+
+// ✅ Correct — grouped variant with its group
+<Typography group="table" variant="cell_header">Tag</Typography>
+<Typography group="table" variant="cell_text">{value}</Typography>
+```
+
+**Rule of thumb:** prefer the group-free quick variants (`h1`–`h6`, `body_short`, `body_long`). Reach for a grouped variant only when you also pass the matching `group`. If unsure whether a variant needs a group, use `body_short` — it always works.
+
 ## Example
 
 ```tsx

--- a/skills/.experimental/fusion-design/references/empty-states.md
+++ b/skills/.experimental/fusion-design/references/empty-states.md
@@ -1,0 +1,41 @@
+# Empty States
+
+An empty state communicates that no content is available yet — on first use, after deletion, when a filter matches nothing, or when access is restricted. Done well it orients the user and offers a path forward. Grounded in `docs/patterns/empty-states.md`.
+
+---
+
+## Rules
+
+- **An empty state is not an error.** If something is *wrong*, that's an error message (see `error-messages.md`). An empty state means the app is working, there's just no content. Never show both at once, and never borrow error styling/language (no error icon, no red/danger colour, no failure wording).
+- **Use positive, action-oriented titles.** `Start by adding data` — never `No data found` / `No results`. Negative phrasing discourages.
+- **Explain the next step in the body.** State what to do (and briefly why the space is empty if it isn't obvious). Highlight the benefit of acting.
+- **At most one primary action; two actions total is the hard limit.** Empty states are calm — don't overcrowd.
+- **Never use an empty state as decorative filler.** Every element must serve the user's next action.
+- Use EDS components and `Typography` — no bare HTML text.
+
+## Anatomy
+
+| Element | Guidance |
+|---|---|
+| Icon | Informational icon signalling the context |
+| Title | Positive phrasing — `Start by creating a report` |
+| Subheading (optional) | Secondary context supporting the title |
+| Body | The next step, and the benefit of taking it |
+| Primary action (optional) | One CTA — button or inline link |
+| Secondary action (optional) | A supporting link, e.g. to a help article |
+
+## Component choice
+
+| Component | Use when |
+|---|---|
+| **Message** | Persistent UI — lists, tables, dashboards where content is expected but absent. The default for a page/section empty state. |
+| **Banner** | Contextual, non-disruptive notice — e.g. missing permissions or a setup step. |
+| **Dialog** | The empty state requires immediate action/awareness — first-time setup, critical missing config, onboarding. |
+
+## Common contexts
+
+| Context | Copy angle |
+|---|---|
+| First use (nothing created yet) | Invite creation — `Start by creating your first …` |
+| Filter/search returns nothing | `No results match …` + a way to clear the filter (distinct from first-use) |
+| Access restricted / temporary issue | Explain gently without framing it as the user's failure |

--- a/skills/.experimental/fusion-design/references/error-messages.md
+++ b/skills/.experimental/fusion-design/references/error-messages.md
@@ -1,0 +1,38 @@
+# Error Messages
+
+An error message tells the user something went wrong, why, and what to do next. Grounded in `docs/patterns/error-messages.md` and the error/status voice in `docs/guidelines/ux-writing.md`.
+
+---
+
+## Placement
+
+- **Show the error where the problem is** — inline, next to or in place of the element/region that failed. Not as a global overlay.
+- **Modal `Dialog` only for critical, blocking errors.** A non-blocking failure (e.g. a failed data load) uses an inline message, not a modal.
+- **Never use a snackbar or toast for an actionable error** — it disappears before the user can act. Toasts are for transient confirmations only.
+- **Don't show errors before the user has acted.** Validate after submit; for error-prone inputs, give real-time guidance instead of pre-emptive blocking errors.
+
+## Content
+
+- State, in order: **what happened → the cause (if useful) → the next step.** Put the key info first.
+- Plain, concise language — no jargon the user can't act on. `Save failed. Please try again.` not `Request failed with status 500`.
+- Give a specific fix when possible (`Use DD/MM/YYYY format`). If recovery is out of the user's hands, say when/how the system will recover.
+
+## Voice (impersonal, non-blaming)
+
+- Use impersonal, action-named phrasing. **Not** first person, **not** user-blaming:
+  - ✅ `Save failed — permission may be required.`
+  - ❌ `We couldn't save` (consumer voice)
+  - ❌ `You don't have permission` (blames the user)
+- For high-impact failures (downtime, data loss), acknowledge with empathy and confirm recovery is in progress.
+- No humour.
+
+## Efficiency & support
+
+- **Preserve user input** after an error — never clear the form. Highlight the problematic field while keeping the entry.
+- **Provide escalation affordances:** an **Error ID**, a **Copy** button, and a **Show details** control for technical context.
+- **Confirm when resolved** — once fixed (by user or system), show a clear confirmation (`Connection restored. Changes synced.`).
+
+## Accessibility
+
+- Screen-reader friendly; sufficient contrast; never rely on colour alone to signal an error.
+- Use EDS components and `Typography` — no bare HTML text.

--- a/skills/.experimental/fusion-design/references/layout-centered-content.md
+++ b/skills/.experimental/fusion-design/references/layout-centered-content.md
@@ -1,0 +1,35 @@
+# Layout — Centered Content
+
+Use centered content for reading-heavy or form-heavy pages where line length matters. The content block is capped at a max-width and aligned to the center of the available space.
+
+## Rules
+
+- **Cap at `1024px` for detail and entity views** — forms, settings, and wizards use `768px`.
+- **Never use `1280px` when a sidemenu is present** — it overflows the content area at the primary viewport (1920×1080 at 125% scaling ≈ 1536px effective CSS width; minus the sidemenu ≈ 1260px available).
+- **The header must align to the same max-width as the content** — they must never be different widths.
+- **Equal margins on both sides** — center using `margin-inline: auto`, not fixed left/right offsets.
+- **On wide screens, outer margins grow — the content block does not expand** beyond the max-width cap.
+
+## When to use
+
+| Page type | Max-width |
+|---|---|
+| Detail view / entity view | `1024px` |
+| Form / settings / configuration | `768px` |
+| Wizard / step-by-step flow | `768px` |
+| Long-form text / documentation | `768px` |
+
+## Spacing
+
+Apply EDS spacing variables to the content block — never hardcode pixel values.
+
+| Context | Property | Variable |
+|---|---|---|
+| Page / view | Vertical padding | `--eds-spacing-inset-xl-vertical-squared` |
+| Page / view | Horizontal padding | `--eds-spacing-inset-xl-horizontal` |
+| Container (card, section) | Vertical padding | `--eds-spacing-inset-md-vertical-squared` |
+| Container (card, section) | Horizontal padding | `--eds-spacing-inset-md-horizontal` |
+
+## Navigation
+
+A centered single-page view has no sidemenu, tab bar, or breadcrumbs. These are only added when the app has multiple sections or navigation depth.

--- a/skills/.experimental/fusion-design/references/layout.md
+++ b/skills/.experimental/fusion-design/references/layout.md
@@ -36,6 +36,7 @@ Content stretches edge to edge, capped at `1584px` on wide screens. Always maint
 
 - Dashboards, card layouts, list views, multi-column tables
 - Internal padding: use page/view spacing variables from the spacing reference — `--eds-spacing-inset-xl-vertical-squared` (vertical) and `--eds-spacing-inset-xl-horizontal` (horizontal). Never hardcode pixel values.
+- **Data tables and lists must fill the full content width** — set `width: 100%` on the table/list. EDS `Table` (and a plain `<table>`) sizes to its content by default, so without this it collapses to a narrow column on the left and wastes the horizontal space that makes dense data scannable.
 - If a **single** viewport-filling component (AG Grid, map) occupies the entire area, use **C — Viewport-fill** instead
 - Never use zero padding — content must not touch the edges
 

--- a/skills/.experimental/fusion-design/references/layout.md
+++ b/skills/.experimental/fusion-design/references/layout.md
@@ -1,0 +1,93 @@
+# Layout — Content Area Patterns
+
+Three accepted patterns for the content area (everything below the header, right of sidemenu if present). Pick **one per page** and apply consistently.
+
+---
+
+## Pattern selection
+
+| Page type | Pattern | Max-width |
+|---|---|---|
+| AG Grid / data grid | **C — Viewport-fill** | No cap |
+| Map or spatially-driven component | **C — Viewport-fill** | No cap |
+| List view / search results | **B — Full-width** | `1584px` |
+| Dashboard / overview | **B — Full-width** | `1584px` |
+| Detail view / entity view | **A — Centered** | `1024px` |
+| Form / settings / configuration | **A — Centered** | `768px` |
+| Wizard / step-by-step flow | **A — Centered** | `768px` |
+| Long-form text / documentation | **A — Centered** | `768px` |
+
+---
+
+## A — Centered content
+
+Content block is capped at a max-width and centered with equal margins on both sides.
+
+- Forms, settings, detail views, reading-heavy pages
+- `768px` for forms/settings/wizards; `1024px` for detail/entity views
+- Do **not** use `1280px` when a sidemenu is present — it overflows the content area at the primary viewport (1920×1080 at 125% scaling ≈ 1536px effective width)
+- Header must align to the same max-width as the content
+
+---
+
+## B — Full-width content
+
+Content stretches edge to edge, capped at `1584px` on wide screens. Always maintains internal padding.
+
+- Dashboards, card layouts, list views, multi-column tables
+- Internal padding: use page/view spacing variables from the spacing reference — `--eds-spacing-inset-xl-vertical-squared` (vertical) and `--eds-spacing-inset-xl-horizontal` (horizontal). Never hardcode pixel values.
+- If a **single** viewport-filling component (AG Grid, map) occupies the entire area, use **C — Viewport-fill** instead
+- Never use zero padding — content must not touch the edges
+
+---
+
+## C — Viewport-fill
+
+A single component fills all available width **and** height. No max-width cap. No outer padding. The component manages its own internal scrolling.
+
+**Use for:** AG Grid pages, maps, any tool-mode component that is the entire page.
+
+### Height rules (critical)
+
+The page itself must **not** scroll — the component handles all internal scrolling.
+
+- Root shell: `height: 100vh; display: flex; flex-direction: column; overflow: hidden`
+- Tab bar / header: `flex-shrink: 0` (auto/fixed height)
+- Tab content area: `flex: 1; overflow: hidden; min-height: 0`
+- The viewport-fill component inside: `width: 100%; height: 100%`
+
+If **any** ancestor has `auto` height without `min-height: 0`, the component will overflow and cause page-level scrolling — fix the entire chain from root down.
+
+### AG Grid specifics
+
+```tsx
+// AG Grid tab panel — overflow: hidden, grid scrolls internally
+<div style={{ flex: 1, overflow: 'hidden', minHeight: 0 }}>
+  <div style={{ width: '100%', height: '100%' }} className="ag-theme-quartz">
+    <AgGridReact ... />
+  </div>
+</div>
+
+// All other tab panels — overflow-y: auto, normal panel scroll
+// Use EDS page spacing vars — never hardcode padding values
+<div style={{ flex: 1, overflowY: 'auto', paddingBlock: 'var(--eds-spacing-inset-xl-vertical-squared)', paddingInline: 'var(--eds-spacing-inset-xl-horizontal)' }}>
+  <OverviewPage />
+</div>
+```
+
+When tabs are used, each tab panel controls its own overflow independently. Only the viewport-fill panel uses `overflow: hidden` — other panels use `overflow-y: auto` so their content can scroll normally if it exceeds the panel height. Never apply `overflow: hidden` to all tab panels uniformly.
+
+### Don'ts
+
+- Don't add a max-width cap — it forces horizontal scrolling inside the component
+- Don't wrap the component in a scrollable container
+- Don't add outer padding — the component owns its internal spacing
+- Don't let any ancestor have unconstrained `auto` height
+
+---
+
+## Cross-pattern rules
+
+- Pick one pattern per page — never mix on the same page
+- The header always matches the content width (centered header + full-width content is not allowed)
+- Don't set a fixed pixel height on the content area

--- a/skills/.experimental/fusion-design/references/navigation-sidemenu.md
+++ b/skills/.experimental/fusion-design/references/navigation-sidemenu.md
@@ -1,0 +1,48 @@
+# Navigation — Sidemenu
+
+Source: `docs/guidelines/navigation/navigation-sidemenu.md`
+
+## Rules
+
+- **Use a sidemenu when the app has 3 or more distinct sections** — for fewer than 3 sections, use tabs instead.
+- **Never combine sidemenu and tabs at the same hierarchy level** — the sidemenu handles all top-level navigation on its own.
+- **Maximum navigation depth is 4 levels** — if the app requires more, reconsider the information architecture.
+- **Expand the sidemenu by default on first arrival** — never hide or collapse it on load.
+- **Never put state-driven actions in the sidemenu** (Save, Delete, Confirm) — place actions in the content area.
+- **Never create single-child groups** — if a parent has only one child, flatten it to a top-level item.
+
+## Structure levels
+
+| Level | Description |
+|---|---|
+| A | App root / landing page — first breadcrumb segment |
+| B | Top-level sections — primary sidemenu items |
+| C | Child items — indented under their parent B when expanded |
+| D | Deepest recommended level — do not go beyond this |
+
+## Breadcrumbs
+
+- Show breadcrumbs when the app has 2 or more levels of navigation depth.
+- **Never** show breadcrumbs on the top-level entry point — there is nowhere to navigate back to.
+- The current page is the last breadcrumb segment and is **not** a clickable link.
+- Each breadcrumb item links to the index/overview of that level.
+- Use the actual entity name for dynamic segments — not a generic label.
+- **Never** style breadcrumbs as tabs — they are different patterns with different meanings.
+- **Never** truncate breadcrumb items unless screen space is critically limited.
+
+## Example structure
+
+```
+App (A)
+├── Overview (B)
+├── Applications (B)
+│   ├── App list (C)
+│   └── App details (C)
+├── Settings (B)
+│   ├── Users (C)
+│   ├── Roles (C)
+│   └── Integrations (C)
+└── Help (B)
+```
+
+Breadcrumb when on Settings › Roles: **App** › **Settings** › Roles

--- a/skills/.experimental/fusion-design/references/navigation-sidemenu.md
+++ b/skills/.experimental/fusion-design/references/navigation-sidemenu.md
@@ -1,7 +1,5 @@
 # Navigation — Sidemenu
 
-Source: `docs/guidelines/navigation/navigation-sidemenu.md`
-
 ## Rules
 
 - **Use a sidemenu when the app has 3 or more distinct sections** — for fewer than 3 sections, use tabs instead.

--- a/skills/.experimental/fusion-design/references/navigation-tabs.md
+++ b/skills/.experimental/fusion-design/references/navigation-tabs.md
@@ -1,0 +1,43 @@
+# Navigation — Tabs
+
+## Rules
+
+- **Use tabs when the app has 2–5 closely related views** — for more than 5 top-level sections, use a sidemenu instead.
+- **Never nest tabs** — if a tab requires sub-navigation, the structure needs rethinking.
+- **Never combine tabs with a sidemenu at the same hierarchy level** — tabs handle all top-level navigation on their own.
+- **Never use tabs for unrelated content** — all tabs must belong to the same entity or context.
+- **Always left-align tabs** — never center-align.
+- **Never style breadcrumbs as tabs** — they are different patterns with different meanings.
+
+## Structure levels
+
+| Level | Description |
+|---|---|
+| A | App or page title — displayed in the header above the tab bar |
+| B | The tab bar — all tabs are siblings at the same level, no hierarchy |
+
+All B items are siblings. There are no child items. The active tab is highlighted.
+
+## Breadcrumbs
+
+- **Do not show breadcrumbs** when tabs are the primary navigation — the user is always at the top level.
+- The page title alone is sufficient to orient the user in a tab-based layout.
+- **Never** style breadcrumbs as tabs — they are different patterns with different meanings.
+
+## AG Grid layout rule
+
+When a tab contains an AG Grid:
+- The grid must fill the full available height of the content area — no fixed height, no scrollable wrapper.
+- The grid handles its own internal scrolling — the page must not scroll.
+- Use `height: 100%` from root down to the grid — no ancestor may have a fixed or auto height that cuts it off.
+
+## Example structure
+
+```
+App (A)
+├── Overview (B)
+├── Members (B)
+└── Settings (B)
+```
+
+No breadcrumbs are shown. The user is always at the top level within the tab bar.

--- a/skills/.experimental/fusion-design/references/spacing.md
+++ b/skills/.experimental/fusion-design/references/spacing.md
@@ -1,0 +1,68 @@
+# Spacing
+
+Always use EDS spacing variables. Never hardcode spacing values.
+
+---
+
+## When spacing is required
+
+Spacing variables are not required on every element. Apply them when the element needs explicit padding or gap — and when you do, always use the correct EDS variable for the context.
+
+---
+
+## Page / view spacing
+
+Applied to the main application view — the outermost layout container.
+
+| Property | Variable |
+|---|---|
+| Vertical padding | `--eds-spacing-inset-xl-vertical-squared` |
+| Horizontal padding | `--eds-spacing-inset-xl-horizontal` |
+| Vertical gap | `--eds-spacing-vertical-xl` |
+| Horizontal gap | `--eds-spacing-horizontal-xl` |
+
+---
+
+## Container spacing
+
+Applied to non-interactive grouping elements — sections, cards, panels.
+
+| Property | Variable |
+|---|---|
+| Vertical padding | `--eds-spacing-inset-md-vertical-squared` |
+| Horizontal padding | `--eds-spacing-inset-md-horizontal` |
+| Vertical gap | `--eds-spacing-vertical-md` |
+| Horizontal gap | `--eds-spacing-horizontal-md` |
+
+---
+
+## Selectable / interactive spacing
+
+Applied to interactive elements — buttons, toggles, clickable icons.
+
+| Property | Variable |
+|---|---|
+| Vertical padding | `--eds-spacing-inset-xs-vertical-squared` |
+| Horizontal padding | `--eds-spacing-inset-xs-horizontal` |
+| Vertical gap | `--eds-spacing-vertical-xs` |
+| Horizontal gap | `--eds-spacing-horizontal-xs` |
+| Icon gap | `--eds-icon-$(icon-size)-gap-horizontal` |
+
+---
+
+## Generic spacing
+
+For cases not covered above — use `--eds-spacing-[vertical|horizontal]-[size]` per side.
+
+**Sizes (use exactly as written):** `4xs` `3xs` `2xs` `xs` `sm` `md` `lg` `xl` `2xl` `3xl`
+
+Do **not** expand size abbreviations — `md` is correct, `medium` is not; `xl` is correct, `x-large` is not.
+
+---
+
+## Rules
+
+- Never write `padding: 16px`, `gap: 24px`, or similar hardcoded values — use the variables above
+- Match the variable tier to the element context: page → `xl`, container → `md`, interactive → `xs`
+- Use `--eds-spacing-inset-*` for padding on layout containers; use `--eds-spacing-vertical/horizontal-*` for gaps between elements
+- For border-radius use `--eds-spacing-border-radius-rounded` (subtle) or `--eds-spacing-border-radius-pill` (full pill) — do **not** invent names like `--eds-shape-corners-*` or `--eds-shape-border-radius-*`


### PR DESCRIPTION
Extends the experimental `fusion-design` skill with new references and two correctness fixes.

## References added
- **`references/navigation-sidemenu.md`** — sidemenu structure, hierarchy, breadcrumb rules
- **`references/navigation-tabs.md`** — tab navigation rules
- **`references/layout.md`** — content-area layout patterns
- **`references/spacing.md`** — EDS spacing variable usage
- **`references/actions.md`** — action bar (experimental), destructive-action `Dialog` structure, button placement
- **`references/layout-centered-content.md`** — centered-content layout for form/reading-heavy pages

## Fixes (surfaced by scenario evals)
- **`eds-typography.md`** — document the grouped-variant trap: `cell_header`/`cell_text` require `group="table"`. Passes `tsc`/build but crashes at runtime without it; steer toward group-free quick variants.
- **`layout.md`** — data tables and lists must fill the full content width (`width: 100%`) in the full-width pattern; EDS `Table` sizes to content by default otherwise.

## Skill wiring
- **`SKILL.md`** — reference table updated to include the new references.

Changesets included for release.