### PR TITLE
fix(ci): prune deprecated skill from skills-lock.json on removal

### DIFF
--- a/.github/workflows/skills-update.yml
+++ b/.github/workflows/skills-update.yml
@@ -565,8 +565,10 @@ jobs:
       # -------------------------------------------------------------------
       # STEP 4: Remove the deprecated skill
       # -------------------------------------------------------------------
-      # Use the skills CLI to remove the skill — it knows the correct
-      # install path and handles skills-lock.json cleanup.
+      # Use the skills CLI to remove the skill's installed files, then prune
+      # the entry from skills-lock.json ourselves. The CLI removes the files
+      # under .agents/skills/ but does NOT update skills-lock.json, so the
+      # lockfile entry must be deleted explicitly to fully remove the skill.
       - name: Remove deprecated skill
         if: steps.pr_state.outputs.blocked != 'true'
         shell: bash
@@ -575,7 +577,17 @@ jobs:
         run: |
           set -euo pipefail
           npx -y skills remove "$SKILL" -y
-          echo "Removed $SKILL via skills CLI"
+          echo "Removed $SKILL files via skills CLI"
+
+          lockfile="skills-lock.json"
+          if [ -f "$lockfile" ] && jq -e --arg s "$SKILL" '.skills | has($s)' "$lockfile" >/dev/null 2>&1; then
+            tmp=$(mktemp)
+            jq --arg s "$SKILL" 'del(.skills[$s])' "$lockfile" > "$tmp"
+            mv "$tmp" "$lockfile"
+            echo "Removed $SKILL entry from $lockfile"
+          else
+            echo "No $SKILL entry found in $lockfile — nothing to prune."
+          fi
 
       # -------------------------------------------------------------------
       # STEP 4b: Install successor skill (if available)

--- a/.github/workflows/skills-update.yml
+++ b/.github/workflows/skills-update.yml
@@ -580,14 +580,35 @@ jobs:
           echo "Removed $SKILL files via skills CLI"
 
           lockfile="skills-lock.json"
-          if [ -f "$lockfile" ] && jq -e --arg s "$SKILL" '.skills | has($s)' "$lockfile" >/dev/null 2>&1; then
-            tmp=$(mktemp)
-            jq --arg s "$SKILL" 'del(.skills[$s])' "$lockfile" > "$tmp"
-            mv "$tmp" "$lockfile"
-            echo "Removed $SKILL entry from $lockfile"
-          else
-            echo "No $SKILL entry found in $lockfile — nothing to prune."
+          if [ ! -f "$lockfile" ]; then
+            echo "No $lockfile present — nothing to prune."
+            exit 0
           fi
+
+          # Query whether the entry exists, distinguishing a genuine "absent
+          # key" (jq -e exit code 1) from real failures such as invalid JSON or
+          # a missing jq binary (exit code >1). Swallowing the latter as "no
+          # entry" would silently leave a stale lockfile entry behind.
+          set +e
+          jq -e --arg s "$SKILL" '.skills | has($s)' "$lockfile" >/dev/null
+          jq_status=$?
+          set -e
+
+          case "$jq_status" in
+            0)
+              tmp=$(mktemp)
+              jq --arg s "$SKILL" 'del(.skills[$s])' "$lockfile" > "$tmp"
+              mv "$tmp" "$lockfile"
+              echo "Removed $SKILL entry from $lockfile"
+              ;;
+            1)
+              echo "No $SKILL entry found in $lockfile — nothing to prune."
+              ;;
+            *)
+              echo "::error::Failed to inspect $lockfile (jq exit $jq_status) — refusing to skip lockfile pruning." >&2
+              exit "$jq_status"
+              ;;
+          esac
 
       # -------------------------------------------------------------------
       # STEP 4b: Install successor skill (if available)


### PR DESCRIPTION
## Why

The scheduled skills-update workflow's deprecation cleanup never actually removed the deprecated skill from `skills-lock.json`. The "Remove deprecated skill" step relied solely on `npx skills remove`, whose comment claimed it "handles skills-lock.json cleanup" — but the CLI only deletes the installed files under `.agents/skills/` and leaves the lockfile entry intact. The result was removal PRs that dropped the files but kept a stale lockfile entry, so the skill was never fully removed.

## Current behavior

`npx skills remove <skill> -y` deletes the skill files but does not touch `skills-lock.json`. Reproduced locally: after removal the lockfile still contained the removed skill's entry.

## New behavior

After running `npx skills remove`, the step now explicitly prunes the entry from `skills-lock.json` using `jq` (`del(.skills[$s])`), guarded by a `has($s)` check so it's a no-op when the entry is already absent. Downstream change detection already diffs `skills-lock.json`, so the lockfile removal is included in the generated PR.

## References

- Issue(s): Related to vercel-labs/skills#808 (upstream CLI behavior: `remove` does not update the lockfile)
- Related PR(s):
- Docs / specs:

## Reviewer focus

- Start here (files/areas): `.github/workflows/skills-update.yml` — "Remove deprecated skill" step (STEP 4)
- Verify these behavior changes: lockfile entry is pruned via `jq` after CLI removal; no-op path when entry already missing
- Risky or security-sensitive parts: none; scoped to a single workflow step

## Self review checklist

- [x] I scoped this PR to one clear purpose.
- [x] I followed [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I did not include secrets, credentials, or sensitive data.
- [x] I reviewed my own diff for clarity and unintended changes.